### PR TITLE
Migrate indicator to GTK4 + Libadwaita

### DIFF
--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -612,9 +612,9 @@ class ReportDialog(Gtk.Window):
 
         self.stack = Gtk.Stack()
 
-        vboxrv = Gtk.VBox()
-        vboxmv = Gtk.VBox()
-        vboxev = Gtk.VBox()
+        vboxrv = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        vboxmv = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        vboxev = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         # Report View
 
@@ -623,7 +623,7 @@ class ReportDialog(Gtk.Window):
         vboxrv.set_margin_top(10)
         vboxrv.set_margin_bottom(10)
 
-        hboxrv = Gtk.HBox()
+        hboxrv = Gtk.Box()
         hboxrv.set_margin_start(5)
         hboxrv.set_margin_end(5)
 
@@ -659,7 +659,7 @@ class ReportDialog(Gtk.Window):
         vboxmv.set_margin_top(10)
         vboxmv.set_margin_bottom(10)
 
-        hboxmv = Gtk.HBox()
+        hboxmv = Gtk.Box()
         hboxmv.set_margin_start(10)
         hboxmv.set_margin_end(10)
         hboxmv.set_margin_top(15)
@@ -686,7 +686,7 @@ class ReportDialog(Gtk.Window):
         vboxev.set_margin_top(10)
         vboxev.set_margin_bottom(10)
 
-        hboxev = Gtk.HBox()
+        hboxev = Gtk.Box()
         hboxev.set_margin_start(10)
         hboxev.set_margin_end(10)
         hboxev.set_margin_top(15)
@@ -794,7 +794,7 @@ class PreferencesDialog(Gtk.Window):
         header.pack_end(self.btn_save)
         self.set_titlebar(header)
 
-        vbox0 = Gtk.VBox(spacing=5)
+        vbox0 = Gtk.Box.new(Gtk.Orientation.VERTICAL, 5)
         vbox0.set_border_width(20)
         self.add(vbox0)
         table1 = Gtk.Table(n_rows=10, n_columns=2, homogeneous=False)
@@ -1035,6 +1035,7 @@ class SystemInfoDialog(Gtk.Dialog):
 
             hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
 
+
             hbox.pack_start(label_key, False, False, 1)
             hbox.pack_end(label_value, False, False, 1)
 
@@ -1101,7 +1102,7 @@ class NotificationsDialog(Gtk.Window):
 
         self.set_titlebar(header)
 
-        vbox = Gtk.VBox(spacing=12)
+        vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 12)
         sw = Gtk.ScrolledWindow()
         self.listbox = Gtk.ListBox()
 

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -772,149 +772,51 @@ class ReportThread(threading.Thread):
 
 class PreferencesDialog(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self)
-        self.set_modal(True)
+        super().__init__(modal=True, window_position=Gtk.WindowPosition.CENTER_ALWAYS)
+        self.connect('delete-event', self.on_delete_event)
 
-        self.connect("delete-event", self.on_delete_event)
+        self.set_icon(GdkPixbuf.Pixbuf.new_from_file_at_scale(common.ICON, 64, 64, True))
 
-        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        theme = Gtk.IconTheme()
-        pix = theme.load_icon(
-            icon_name=common.ICON, size=64, flags=Gtk.IconLookupFlags.FORCE_SYMBOLIC
-        )
-        self.set_icon(pix)
-
-        header = Gtk.HeaderBar()
-        header.set_title(_("Slimbook Preferences"))
-        header.set_show_close_button(True)
-
-        self.btn_save = Gtk.Button.new_with_label(_("Save"))
-        self.btn_save.set_sensitive(False)
-        self.btn_save.connect("clicked", self.on_btn_save_clicked)
-        header.pack_end(self.btn_save)
+        header = Gtk.HeaderBar(title=_('Slimbook Preferences'), show_close_button=True)
         self.set_titlebar(header)
+        
+        self.btn_save = Gtk.Button(label=_('Save'), sensitive=False)
+        self.btn_save.connect('clicked', self.on_btn_save_clicked)
+        header.pack_end(self.btn_save)
 
-        vbox0 = Gtk.Box.new(Gtk.Orientation.VERTICAL, 5)
-        vbox0.set_border_width(20)
-        self.add(vbox0)
-        table1 = Gtk.Table(n_rows=10, n_columns=2, homogeneous=False)
-        vbox0.pack_start(table1, False, True, 1)
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5, border_width=20)
+        self.add(vbox)
 
-        label0 = Gtk.Label(label=_("Show indicator") + ":")
-        label0.set_halign(Gtk.Align.CENTER)
-        table1.attach(label0, 0, 1, 6, 7, xpadding=15, ypadding=15)
-        self.switch0 = Gtk.Switch()
-        table1.attach(
-            self.switch0,
-            1,
-            2,
-            6,
-            7,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
+        list_box = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
+        vbox.add(list_box)
 
-        label1 = Gtk.Label(label=_("Autostart") + ":")
-        label1.set_halign(Gtk.Align.CENTER)
-        table1.attach(label1, 0, 1, 7, 8, xpadding=15, ypadding=15)
-        self.switch1 = Gtk.Switch()
-        table1.attach(
-            self.switch1,
-            1,
-            2,
-            7,
-            8,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
+        preferences = [
+            ('switch0', _('Show indicator')),
+            ('switch1', _('Autostart')),
+            ('switch2', _('Light-mode Icon')),
+            ('switch3', _('Check Notifications')),
+            ('switch4', _('Trackpad lock')),
+            ('switch5', _('Set power profile')),
+            ('switch6', _('AC Notifications')),
+        ]
 
-        label2 = Gtk.Label(label=_("Light-mode Icon") + ":")
-        label2.set_halign(Gtk.Align.CENTER)
-        table1.attach(label2, 0, 1, 8, 9, xpadding=15, ypadding=15)
-        self.switch2 = Gtk.Switch()
-        table1.attach(
-            self.switch2,
-            1,
-            2,
-            8,
-            9,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
+        for attr, label_text in preferences:
+            row = Gtk.ListBoxRow(activatable=False, selectable=False)
+            box = Gtk.Box()
+            row.add(box)
 
-        label3 = Gtk.Label(label=_("Check Notifications") + ":")
-        label3.set_halign(Gtk.Align.CENTER)
-        table1.attach(label3, 0, 1, 9, 10, xpadding=15, ypadding=15)
-        self.switch3 = Gtk.Switch()
-        table1.attach(
-            self.switch3,
-            1,
-            2,
-            9,
-            10,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
+            label = Gtk.Label(label=label_text, halign=Gtk.Align.START, valign=Gtk.Align.CENTER, hexpand=True)
+            switch = Gtk.Switch(halign=Gtk.Align.END, valign=Gtk.Align.CENTER)
 
-        label4 = Gtk.Label(label=_("Trackpad lock") + ":")
-        label4.set_halign(Gtk.Align.CENTER)
-        table1.attach(label4, 0, 1, 10, 11, xpadding=15, ypadding=15)
-        self.switch4 = Gtk.Switch()
-        table1.attach(
-            self.switch4,
-            1,
-            2,
-            10,
-            11,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
+            box.add(label)
+            box.add(switch)
+            list_box.add(row)
 
-        label5 = Gtk.Label(label=_("Set power profile") + ":")
-        label5.set_halign(Gtk.Align.CENTER)
-        table1.attach(label5, 0, 1, 11, 12, xpadding=15, ypadding=15)
-        self.switch5 = Gtk.Switch()
-        table1.attach(
-            self.switch5,
-            1,
-            2,
-            11,
-            12,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
-
-        label6 = Gtk.Label(label=_("AC Notifications") + ":")
-        label6.set_halign(Gtk.Align.CENTER)
-        table1.attach(label6, 0, 1, 12, 13, xpadding=15, ypadding=15)
-        self.switch6 = Gtk.Switch()
-        table1.attach(
-            self.switch6,
-            1,
-            2,
-            12,
-            13,
-            xpadding=15,
-            ypadding=15,
-            xoptions=Gtk.AttachOptions.SHRINK,
-        )
+            setattr(self, attr, switch)
+            switch.connect('state-set', self.on_switch_state_set)
 
         self.load_preferences()
-
         self.changes = False
-        self.switch0.connect("state-set", self.on_switch_state_set)
-        self.switch1.connect("state-set", self.on_switch_state_set)
-        self.switch2.connect("state-set", self.on_switch_state_set)
-        self.switch3.connect("state-set", self.on_switch_state_set)
-        self.switch4.connect("state-set", self.on_switch_state_set)
-        self.switch5.connect("state-set", self.on_switch_state_set)
-        self.switch6.connect("state-set", self.on_switch_state_set)
 
         self.show_all()
 

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -26,6 +26,7 @@ import slimbook.info
 import zmq
 import feedparser
 import gi
+import sni
 
 import logging
 import threading
@@ -43,33 +44,23 @@ import datetime
 from dateutil import parser
 
 
-try:
-    gi.require_version("Gtk", "3.0")
-    gi.require_version("Gio", "2.0")
-    gi.require_version("GLib", "2.0")
-    gi.require_version("GdkPixbuf", "2.0")
-    gi.require_version("Notify", "0.7")
-
-    try:
-        gi.require_version("AyatanaAppIndicator3", "0.1")
-        from gi.repository import AyatanaAppIndicator3 as appindicator
-    except:
-        gi.require_version("AppIndicator3", "0.1")
-        from gi.repository import AppIndicator3 as appindicator
-except Exception as e:
-    print(e)
-    exit(1)
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("Notify", "0.7")
 
 from gi.repository import GObject
 from gi.repository import Gtk, Gdk, Gio
 from gi.repository import GLib
-from gi.repository import GdkPixbuf
+from gi.repository import Adw
 from gi.repository import Notify
-from gi.repository import GLib
 
-Notify.init("Slimbok Client Notifications")
+Adw.init()
+
+Notify.init("Slimbook Client Notifications")
 notification = Notify.Notification.new("", "")
-notification.set_app_name("Slimbok Client Notifications")
+notification.set_app_name("Slimbook Client Notifications")
 notification.set_timeout(Notify.EXPIRES_DEFAULT)
 notification.set_urgency(Notify.Urgency.NORMAL)
 
@@ -82,15 +73,27 @@ zmq_context = zmq.Context()
 
 
 def update_server_settings(settings):
-    logging.info("Updating server settings...")
-    socket = zmq_context.socket(zmq.REQ)
-    socket.connect("ipc://{0}".format(common.SLB_IPC_CTL_PATH))
+    def _send():
+        logging.info("Updating server settings...")
+        ctx = zmq.Context()
+        sock = ctx.socket(zmq.REQ)
+        sock.setsockopt(zmq.LINGER, 1000)  # wait for in-flight messages on close
+        sock.setsockopt(zmq.SNDTIMEO, 2000)
+        sock.setsockopt(zmq.RCVTIMEO, 2000)
+        sock.connect("ipc://{0}".format(common.SLB_IPC_CTL_PATH))
+        data = {"cmd": common.CMD_LOAD_SETTINGS, "settings": settings}
+        try:
+            sock.send_json(data)
+            sock.recv()
+            logging.info("update_server_settings: OK")
+        except zmq.Again:
+            logging.warning("update_server_settings: service not available")
+        except Exception as e:
+            logging.warning("update_server_settings: error: %s", e)
+        sock.close()
+        ctx.term()
 
-    data = {}
-    data["cmd"] = common.CMD_LOAD_SETTINGS
-    data["settings"] = settings
-    socket.send_json(data)
-    socket.close()
+    threading.Thread(target=_send, daemon=True).start()
 
 
 class Feed:
@@ -102,9 +105,9 @@ class Feed:
             self.id = m.hexdigest()
             self.title = entry.title
             self.body = entry.description
-            self.link = entry.get("link")
+            link = entry.get("link", "")
+            self.link = link if link.startswith(("http://", "https://")) else None
             self.published = entry.get("published")
-            # print("link:",entry.get("link"))
             self.tags = []
             self.icon = "dialog-information"
 
@@ -175,32 +178,13 @@ def check_time_feeds():
 
 
 class ServiceIndicator(GObject.Object):
+    __gsignals__ = {
+        "feed-update-start": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_BOOLEAN,)),
+        "feed-update-complete": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_BOOLEAN,)),
+    }
+
     def __init__(self):
         super().__init__()
-
-        GObject.signal_new(
-            "preferences-close",
-            PreferencesDialog,
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_BOOLEAN,),
-        )
-
-        GObject.signal_new(
-            "feed-update-start",
-            ServiceIndicator,
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_BOOLEAN,),
-        )
-
-        GObject.signal_new(
-            "feed-update-complete",
-            ServiceIndicator,
-            GObject.SignalFlags.RUN_LAST,
-            None,
-            (GObject.TYPE_BOOLEAN,),
-        )
 
         # set up zmq
         self.socket = zmq_context.socket(zmq.SUB)
@@ -210,6 +194,11 @@ class ServiceIndicator(GObject.Object):
         self.poller.register(self.socket, zmq.POLLIN)
 
         GLib.idle_add(self.zmq_loop)
+
+        # menu item sensitivity
+        self._news_sensitive = True
+        self._prefs_sensitive = True
+        self._report_sensitive = True
 
         self.set_indicator()
         Notify.init("Slimbook")
@@ -262,7 +251,7 @@ class ServiceIndicator(GObject.Object):
         self.feed_updating = False
         self.emit("feed-update-complete", False)
 
-        if self.menu_news.get_sensitive():
+        if self._news_sensitive:
             self.check_news()
 
     def check_news(self):
@@ -352,13 +341,12 @@ class ServiceIndicator(GObject.Object):
             logging.error(e)
 
         if warn_user:
-            self.indicator.set_status(appindicator.IndicatorStatus.ATTENTION)
+            self.indicator.set_status(sni.STATUS_NEEDS_ATTENTION)
         else:
-            self.indicator.set_status(
-                appindicator.IndicatorStatus.ACTIVE
-            ) if self.show else self.indicator.set_status(
-                appindicator.IndicatorStatus.PASSIVE
-            )
+            if self.show:
+                self.indicator.set_status(sni.STATUS_ACTIVE)
+            else:
+                self.indicator.set_status(sni.STATUS_PASSIVE)
 
         return news
 
@@ -366,32 +354,85 @@ class ServiceIndicator(GObject.Object):
         logging.debug("Setting indicator...")
         self.active_icon = None
         self.attention_icon = None
-        self.about_dialog = None
         self.active = False
 
         self.notification = Notify.Notification.new("", "", None)
         self.read_preferences()
         manage_autostart(self.autostart)
 
-        self.indicator = appindicator.Indicator.new(
+        self.indicator = sni.StatusNotifierItem(
             "com.slimbook.service",
             self.active_icon,
-            appindicator.IndicatorCategory.HARDWARE,
+            sni.CATEGORY_HARDWARE,
         )
-
         self.indicator.set_title("Slimbook Client Notifications")
-
-        self.indicator.set_attention_icon_full(self.attention_icon, "")
+        self.indicator.set_attention_icon(self.attention_icon)
 
         self.running = True
+        self._refresh_menu()
 
-        self.menu = self.get_menu()
-        self.indicator.set_menu(self.menu)
-        self.indicator.set_status(
-            appindicator.IndicatorStatus.ACTIVE
-        ) if self.show else self.indicator.set_status(
-            appindicator.IndicatorStatus.PASSIVE
-        )
+        if self.show:
+            self.indicator.set_status(sni.STATUS_ACTIVE)
+        else:
+            self.indicator.set_status(sni.STATUS_PASSIVE)
+
+    def _refresh_menu(self):
+        """Rebuild and push the tray menu to the SNI indicator."""
+        self.indicator.set_menu(self._build_menu_items())
+
+    def _build_menu_items(self):
+        """Return a list of SNI menu item descriptors."""
+        items = [
+            {
+                "label": _("Notifications"),
+                "callback": self.on_news_item,
+                "sensitive": self._news_sensitive,
+            },
+            {
+                "label": _("System Information"),
+                "callback": self.on_sysinfo_item,
+            },
+            {
+                "label": _("Preferences"),
+                "callback": self.on_preferences_item,
+                "sensitive": self._prefs_sensitive,
+            },
+        ]
+
+        if os.path.exists(common.CONTROL_PANEL_PATH):
+            items.append({
+                "label": _("Control Panel"),
+                "callback": self.on_control_panel_item,
+            })
+
+        items.append({"type": "separator", "label": ""})
+
+        items += [
+            {
+                "label": _("About"),
+                "callback": self.on_about_item,
+            },
+            {
+                "label": _("Generate Report"),
+                "callback": self.on_report_item,
+                "sensitive": self._report_sensitive,
+            },
+            {
+                "label": _("Report a Bug…"),
+                "callback": lambda: webbrowser.open(
+                    "https://github.com/slimbook/slimbook_service/issues/new"
+                ),
+            },
+        ]
+
+        items.append({"type": "separator", "label": ""})
+
+        items.append({
+            "label": _("Exit"),
+            "callback": self.on_quit_item,
+        })
+
+        return items
 
     def message(self, title, message, icon="dialog-information"):
         notification.update(title, message, icon)
@@ -411,334 +452,187 @@ class ServiceIndicator(GObject.Object):
         # push settings to server
         settings = {}
 
-        for key in [common.OPT_TRACKPAD_LOCK, common.OPT_POWER_PROFILE]:
+        for key in [common.OPT_TRACKPAD_LOCK, common.OPT_POWER_PROFILE, common.OPT_AC_NOTIFICATIONS]:
             value = configuration.get(key)
             if value is not None:
                 settings[key] = value
 
         update_server_settings(settings)
 
-    def get_menu(self):
-        """Create and populate the menu."""
-        menu = Gtk.Menu()
-
-        self.menu_news = Gtk.MenuItem.new_with_label(_("Notifications"))
-        self.menu_news.connect("activate", self.on_news_item)
-        self.menu_news.show()
-        menu.append(self.menu_news)
-
-        menu_sysinfo = Gtk.MenuItem.new_with_label(_("System information"))
-        menu_sysinfo.connect("activate", self.on_sysinfo_item)
-        menu_sysinfo.show()
-        menu.append(menu_sysinfo)
-
-        self.menu_preferences = Gtk.MenuItem.new_with_label(_("Preferences"))
-        self.menu_preferences.connect("activate", self.on_preferences_item)
-        self.menu_preferences.show()
-        menu.append(self.menu_preferences)
-
-        if (os.path.exists(common.CONTROL_PANEL_PATH)):
-            self.menu_control_panel = Gtk.MenuItem.new_with_label(_("Control Panel"))
-            self.menu_control_panel.connect("activate", self.on_control_panel_item)
-            self.menu_control_panel.show()
-            menu.append(self.menu_control_panel)
-
-        separator = Gtk.SeparatorMenuItem()
-        separator.show()
-        menu.append(separator)
-
-        about_item = Gtk.MenuItem.new_with_label(_("About"))
-        about_item.connect("activate", self.on_about_item)
-        about_item.show()
-        menu.append(about_item)
-
-        self.report = Gtk.MenuItem.new_with_label(_("Generate report"))
-        self.report.connect("activate", self.on_report_item)
-        self.report.show()
-        menu.append(self.report)
-
-        bug_item = Gtk.MenuItem(label=_("Report a bug..."))
-        bug_item.connect(
-            "activate",
-            lambda x: webbrowser.open(
-                "https://github.com/slimbook/slimbook_service/issues/new"
-            ),
-        )
-        bug_item.show()
-        menu.append(bug_item)
-
-        separator2 = Gtk.SeparatorMenuItem()
-        separator2.show()
-        menu.append(separator2)
-
-        menu_exit = Gtk.MenuItem.new_with_label(_("Exit"))
-        menu_exit.connect("activate", self.on_quit_item)
-        menu_exit.show()
-        menu.append(menu_exit)
-
-        menu.show()
-
-        return menu
-
-    def get_about_dialog(self):
-        """Create and populate the about dialog."""
-        about_dialog = Gtk.AboutDialog()
-        about_dialog.set_name(common.APPNAME)
-        about_dialog.set_version(common.VERSION)
-        about_dialog.set_copyright("Copyrignt (c) 2024\nSlimbook")
-        about_dialog.set_comments(_("Slimbook Service"))
-        about_dialog.set_license("""
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
-This program is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with
-this program. If not, see <http://www.gnu.org/licenses/>.
-""")
-        about_dialog.set_website("http://www.slimbook.es")
-        about_dialog.set_website_label(_("Visit Website"))
-        link = Gtk.LinkButton(
-            uri=("https://github.com/slimbook/slimbook_service/issues/new"),
-            label=(_("Report issue")),
-        )
-        link.set_name("link")
-        link.set_halign(Gtk.Align.CENTER)
-        about_dialog.set_authors(["Slimbook <dev@slimbook.es>","Antonio Masiá <ajmasia.dev@ysnp.link>"])
-        about_dialog.set_documenters(["Slimbook <dev@slimbook.es>"])
-        about_dialog.set_translator_credits(_("translator-credits"))
-
-        theme = Gtk.IconTheme()
-        pix = theme.load_icon(
-            icon_name=common.ICON, size=125, flags=Gtk.IconLookupFlags.FORCE_SYMBOLIC
-        )
-        about_dialog.set_icon(pix)
-        about_dialog.set_logo(pix)
-        about_dialog.set_program_name(common.APPNAME)
-        return about_dialog
-
-    def on_preferences_item(self, widget, data=None):
+    def on_preferences_item(self, *args):
         self.show_preferences()
 
-    def on_control_panel_item(self, widget, data=None):
+    def on_control_panel_item(self, *args):
         subprocess.Popen([common.CONTROL_PANEL_PATH])
 
-    def on_sysinfo_item(self, widget, data=None):
+    def on_sysinfo_item(self, *args):
         logging.debug("system info")
-        widget.set_sensitive(False)
         info = common.get_system_info()
-
         sysinfo_dialog = SystemInfoDialog(info)
-        sysinfo_dialog.run()
-        sysinfo_dialog.destroy()
-        widget.set_sensitive(True)
+        sysinfo_dialog.present()
 
-    def on_news_item(self, widget, data=None):
+    def on_news_item(self, *args):
         logging.debug("news")
-        widget.set_sensitive(False)
+        self._news_sensitive = False
+        self._refresh_menu()
         news_dialog = NotificationsDialog(self)
-        news_dialog.connect("delete-event", self.on_news_delete_event)
+        news_dialog.connect("close-request", self._on_news_close_request)
+        news_dialog.present()
 
-    def on_quit_item(self, widget, data=None):
+    def on_quit_item(self, *args):
         Notify.uninit()
         logging.debug("Exit")
-        exit(0)
+        if _main_loop:
+            _main_loop.quit()
 
-    def on_about_item(self, widget, data=None):
-        if self.about_dialog:
-            self.about_dialog.present()
-        else:
-            self.about_dialog = self.get_about_dialog()
-            self.about_dialog.run()
-            self.about_dialog.destroy()
-            self.about_dialog = None
-
-    def on_report_item(self, widget, data=None):
-        self.show_report()
-        widget.set_sensitive(True)
-
-    # Interface and Method
-
-    def on_news_delete_event(self, window, event):
-        self.menu_news.set_sensitive(True)
-        self.indicator.set_status(
-            appindicator.IndicatorStatus.ACTIVE
-        ) if self.show else self.indicator.set_status(
-            appindicator.IndicatorStatus.PASSIVE
+    def on_about_item(self, *args):
+        dialog = Adw.AboutDialog(
+            application_name=common.APPNAME,
+            application_icon=common.ICON,
+            version=common.VERSION,
+            developer_name="Slimbook",
+            copyright="Copyright © 2024 Slimbook",
+            comments=_("Slimbook Service"),
+            license_type=Gtk.License.GPL_3_0,
+            website="http://www.slimbook.es",
+            issue_url="https://github.com/slimbook/slimbook_service/issues/new",
+            developers=["Slimbook <dev@slimbook.es>", "Antonio Masiá <ajmasia.dev@ysnp.link>"],
+            documenters=["Slimbook <dev@slimbook.es>"],
+            translator_credits=_("translator-credits"),
         )
+        dialog.present(None)
 
-    def on_preferences_close(self, *args):
-        self.menu_preferences.set_sensitive(True)
+    def on_report_item(self, *args):
+        self.show_report()
+
+    # dialog callbacks
+
+    def _on_news_close_request(self, window):
+        self._news_sensitive = True
+        self._refresh_menu()
+        if self.show:
+            self.indicator.set_status(sni.STATUS_ACTIVE)
+        else:
+            self.indicator.set_status(sni.STATUS_PASSIVE)
+        return False  # allow close
+
+    def on_preferences_close(self, dialog, changes):
+        self._prefs_sensitive = True
+        self._refresh_menu()
         self.read_preferences()
-
-        self.indicator.set_attention_icon_full(self.attention_icon, "")
-        self.indicator.set_icon_full(self.active_icon, "")
+        self.indicator.set_attention_icon(self.attention_icon)
+        self.indicator.set_icon(self.active_icon)
 
     def show_preferences(self):
-        self.menu_preferences.set_sensitive(False)
+        self._prefs_sensitive = False
+        self._refresh_menu()
         preferences_dialog = PreferencesDialog()
         preferences_dialog.connect("preferences-close", self.on_preferences_close)
+        preferences_dialog.present(None)
 
     def show_report(self):
-        self.report.set_sensitive(False)
+        self._report_sensitive = False
+        self._refresh_menu()
         report_dialog = ReportDialog()
+        report_dialog.connect("close-request", self._on_report_close_request)
+        report_dialog.present()
+
+    def _on_report_close_request(self, window):
+        self._report_sensitive = True
+        self._refresh_menu()
+        return False
 
 
-class ReportDialog(Gtk.Window):
+# ---------------------------------------------------------------------------
+# ReportDialog
+# ---------------------------------------------------------------------------
+
+class ReportDialog(Adw.Window):
     def __init__(self):
-        Gtk.Window.__init__(self)
-        self.set_default_size(600, 100)
+        super().__init__()
+        self.set_default_size(500, 520)
         self.set_modal(True)
+        self.set_title(_("Generate Report"))
 
         self.path = ""
-        self.has_ended = False
-
-        self.connect("delete-event", self.on_report_delete_event)
-
-        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        theme = Gtk.IconTheme()
-        pix = theme.load_icon(
-            icon_name=common.ICON, size=64, flags=Gtk.IconLookupFlags.FORCE_SYMBOLIC
-        )
-        self.set_icon(pix)
 
         header = Gtk.HeaderBar()
-        header.set_title(_("Generate report"))
-        header.set_show_close_button(True)
-
-        self.set_titlebar(header)
+        header.set_show_title_buttons(True)
 
         self.stack = Gtk.Stack()
 
-        vboxrv = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        vboxmv = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        vboxev = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-
-        # Report View
-
-        vboxrv.set_margin_start(20)
-        vboxrv.set_margin_end(20)
-        vboxrv.set_margin_top(10)
-        vboxrv.set_margin_bottom(10)
-
-        hboxrv = Gtk.Box()
-        hboxrv.set_margin_start(5)
-        hboxrv.set_margin_end(5)
-
-        report_desc = Gtk.Label.new(
-            _(
-                "This is a report of several hardware and software stats.\nFull report generates a report with sensitive information,\nbeware of sharing it online!"
-            )
+        # Report view
+        status_report = Adw.StatusPage(
+            icon_name="document-send-symbolic",
+            title=_("Generate Report"),
+            description=_(
+                "Creates a compressed archive with hardware and software information. "
+                "The full report also includes sensitive data such as MAC address and board serial number"
+            ),
         )
-
-        vboxrv.pack_start(report_desc, True, True, 4)
-
-        self.progress_bar = Gtk.ProgressBar()
-        self.progress_bar.set_text("")
-        self.progress_bar.set_show_text(True)
-
-        vboxrv.pack_start(self.progress_bar, True, True, 4)
-
         self.normal_report_btn = Gtk.Button.new_with_label(_("Report"))
+        self.normal_report_btn.add_css_class("pill")
         self.normal_report_btn.connect("clicked", self.on_report_button)
-
-        self.full_report_btn = Gtk.Button.new_with_label(_("Full report"))
+        self.full_report_btn = Gtk.Button.new_with_label(_("Full Report"))
+        self.full_report_btn.add_css_class("pill")
         self.full_report_btn.connect("clicked", self.on_full_report_button)
+        btn_box = Gtk.Box(spacing=8, halign=Gtk.Align.CENTER)
+        btn_box.append(self.normal_report_btn)
+        btn_box.append(self.full_report_btn)
+        status_report.set_child(btn_box)
 
-        hboxrv.pack_start(self.normal_report_btn, True, True, 4)
-        hboxrv.pack_start(self.full_report_btn, True, True, 4)
+        # Generating view
+        status_generating = Adw.StatusPage(title=_("Generating…"))
+        spinner = Adw.Spinner()
+        spinner.set_size_request(32, 32)
+        status_generating.set_child(spinner)
 
-        vboxrv.pack_start(hboxrv, True, True, 4)
-
-        # Message View
-
-        vboxmv.set_margin_start(20)
-        vboxmv.set_margin_end(20)
-        vboxmv.set_margin_top(10)
-        vboxmv.set_margin_bottom(10)
-
-        hboxmv = Gtk.Box()
-        hboxmv.set_margin_start(10)
-        hboxmv.set_margin_end(10)
-        hboxmv.set_margin_top(15)
-        hboxmv.set_margin_bottom(15)
-
-        self.path_label = Gtk.Label.new(self.path)
-        vboxmv.pack_start(self.path_label, True, True, 4)
-
-        self.open_btn = Gtk.Button.new_with_label(_("Open"))
+        # Success view
+        self.status_success = Adw.StatusPage(icon_name="object-select-symbolic")
+        self.open_btn = Gtk.Button.new_with_label(_("Open Folder"))
+        self.open_btn.add_css_class("suggested-action")
+        self.open_btn.add_css_class("pill")
+        self.open_btn.set_halign(Gtk.Align.CENTER)
         self.open_btn.connect("clicked", self.on_open_button)
-
-        self.close_btn = Gtk.Button.new_with_label(_("Close"))
-        self.close_btn.connect("clicked", self.on_close_button)
-
-        hboxmv.pack_start(self.open_btn, True, True, 4)
-        hboxmv.pack_start(self.close_btn, True, True, 4)
-
-        vboxmv.pack_start(hboxmv, True, True, 4)
+        self.status_success.set_child(self.open_btn)
 
         # Error view
+        self.status_error = Adw.StatusPage(icon_name="dialog-error-symbolic")
+        close_btn_err = Gtk.Button.new_with_label(_("Close"))
+        close_btn_err.set_halign(Gtk.Align.CENTER)
+        close_btn_err.connect("clicked", self.on_close_button)
+        self.status_error.set_child(close_btn_err)
 
-        vboxev.set_margin_start(20)
-        vboxev.set_margin_end(20)
-        vboxev.set_margin_top(10)
-        vboxev.set_margin_bottom(10)
+        self.stack.add_named(status_report, name="report")
+        self.stack.add_named(status_generating, name="generating")
+        self.stack.add_named(self.status_success, name="success")
+        self.stack.add_named(self.status_error, name="error")
 
-        hboxev = Gtk.Box()
-        hboxev.set_margin_start(10)
-        hboxev.set_margin_end(10)
-        hboxev.set_margin_top(15)
-        hboxev.set_margin_bottom(15)
-
-        self.err_code = ""
-
-        self.err_code_label = Gtk.Label.new(self.err_code)
-
-        vboxev.pack_start(self.err_code_label, True, True, 4)
-
-        self.close_btn_err = Gtk.Button.new_with_label(_("Close"))
-        self.close_btn_err.connect("clicked", self.on_close_button)
-
-        hboxev.pack_start(self.close_btn_err, True, True, 4)
-
-        vboxev.pack_start(hboxev, True, True, 4)
-
-        self.stack.add_named(vboxrv, name="Report view")
-
-        self.stack.add_named(vboxmv, name="Message view")
-
-        self.stack.add_named(vboxev, name="Error view")
-
-        self.add(self.stack)
-
-        self.show_all()
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(self.stack)
+        self.set_content(toolbar_view)
 
     def prog_bar_proc(self, args):
-        if args[0] == True:
-            self.path_label.set_label(_("Succesful! Dumped at ") + self.path)
-            self.resize(200, 100)
-            self.stack.set_visible_child_name("Message view")
-            self.progress_bar.set_fraction(1.0)
-        else:
-            self.progress_bar.pulse()
-
-        if args[1] != "":
-            self.err_code_label.set_label(
-                _("Error! Report wasn't able to be generated\nError: ") + self.err_code
+        done, err_msg, path = args[0], args[1], args[2]
+        if not done:
+            return
+        if err_msg:
+            self.status_error.set_title(_("Error"))
+            self.status_error.set_description(
+                _("The report could not be generated:\n") + err_msg
             )
-            self.stack.set_visible_child_name("Error view")
-            self.resize(200, 100)
-            self.err_code = args[1]
+            self.stack.set_visible_child_name("error")
+        else:
+            self.path = path
+            self.status_success.set_title(_("Report Generated"))
+            self.status_success.set_description(_("Saved at ") + path)
+            self.stack.set_visible_child_name("success")
 
-        if args[2] != "":
-            self.path = args[2]
-
-    def on_report_button_common(self, widget, str):
-        self.bar_thread = ReportThread(self.prog_bar_proc, str)
-        self.bar_thread.start()
+    def on_report_button_common(self, widget, report_type):
+        self.stack.set_visible_child_name("generating")
         self.disable_buttons()
+        ReportThread(self.prog_bar_proc, report_type).start()
 
     def on_report_button(self, widget):
         self.on_report_button_common(widget, "report")
@@ -756,9 +650,10 @@ class ReportDialog(Gtk.Window):
     def on_open_button(self, widget):
         subprocess.Popen(["xdg-open", os.path.dirname(self.path)])
 
-    def on_report_delete_event(self, window, event):
-        self.set_sensitive(False)
 
+# ---------------------------------------------------------------------------
+# ReportThread
+# ---------------------------------------------------------------------------
 
 class ReportThread(threading.Thread):
     def __init__(self, cb, report_type):
@@ -770,72 +665,69 @@ class ReportThread(threading.Thread):
         common.report_proc(self, GLib.idle_add, self.callback, self.report_type)
 
 
-class PreferencesDialog(Gtk.Window):
+# ---------------------------------------------------------------------------
+# PreferencesDialog
+# ---------------------------------------------------------------------------
+
+class PreferencesDialog(Adw.PreferencesDialog):
+    __gsignals__ = {
+        "preferences-close": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_BOOLEAN,))
+    }
+
+    _PREFS = [
+        ("switch0", lambda: _("Show Indicator")),
+        ("switch1", lambda: _("Autostart")),
+        ("switch2", lambda: _("Light-Mode Icon")),
+        ("switch3", lambda: _("Check Notifications")),
+        ("switch4", lambda: _("Trackpad Lock")),
+        ("switch5", lambda: _("Set Power Profile")),
+        ("switch6", lambda: _("AC Notifications")),
+    ]
+
     def __init__(self):
-        super().__init__(modal=True, window_position=Gtk.WindowPosition.CENTER_ALWAYS)
-        self.connect('delete-event', self.on_delete_event)
+        super().__init__()
+        self.set_title(_("Slimbook Preferences"))
+        self._changes = False
+        self.connect("closed", self._on_dialog_closed)
 
-        self.set_icon(GdkPixbuf.Pixbuf.new_from_file_at_scale(common.ICON, 64, 64, True))
+        page = Adw.PreferencesPage()
+        self.add(page)
 
-        header = Gtk.HeaderBar(title=_('Slimbook Preferences'), show_close_button=True)
-        self.set_titlebar(header)
-        
-        self.btn_save = Gtk.Button(label=_('Save'), sensitive=False)
-        self.btn_save.connect('clicked', self.on_btn_save_clicked)
-        header.pack_end(self.btn_save)
+        group = Adw.PreferencesGroup()
+        page.add(group)
 
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5, border_width=20)
-        self.add(vbox)
+        for attr, label_fn in self._PREFS:
+            row = Adw.SwitchRow(title=label_fn())
+            group.add(row)
+            setattr(self, attr, row)
 
-        list_box = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
-        vbox.add(list_box)
+        self.btn_save = Gtk.Button.new_with_label(_("Save"))
+        self.btn_save.add_css_class("suggested-action")
+        self.btn_save.add_css_class("pill")
+        self.btn_save.set_halign(Gtk.Align.CENTER)
+        self.btn_save.set_margin_top(12)
+        self.btn_save.set_sensitive(False)
+        self.btn_save.connect("clicked", self._on_btn_save_clicked)
+        group.add(self.btn_save)
 
-        preferences = [
-            ('switch0', _('Show indicator')),
-            ('switch1', _('Autostart')),
-            ('switch2', _('Light-mode Icon')),
-            ('switch3', _('Check Notifications')),
-            ('switch4', _('Trackpad lock')),
-            ('switch5', _('Set power profile')),
-            ('switch6', _('AC Notifications')),
-        ]
+        self._load_preferences()
 
-        for attr, label_text in preferences:
-            row = Gtk.ListBoxRow(activatable=False, selectable=False)
-            box = Gtk.Box()
-            row.add(box)
+        for attr, __ in self._PREFS:
+            getattr(self, attr).connect("notify::active", self._on_switch_changed)
 
-            label = Gtk.Label(label=label_text, halign=Gtk.Align.START, valign=Gtk.Align.CENTER, hexpand=True)
-            switch = Gtk.Switch(halign=Gtk.Align.END, valign=Gtk.Align.CENTER)
-
-            box.add(label)
-            box.add(switch)
-            list_box.add(row)
-
-            setattr(self, attr, switch)
-            switch.connect('state-set', self.on_switch_state_set)
-
-        self.load_preferences()
-        self.changes = False
-
-        self.show_all()
-
-    def on_switch_state_set(self, switch, state):
+    def _on_switch_changed(self, row, _param):
+        self._changes = True
         self.btn_save.set_sensitive(True)
-        self.changes = True
 
-    def on_delete_event(self, window, event):
-        self.emit("preferences-close", self.changes)
-        return False
-
-    def on_btn_save_clicked(self, widget):
-        self.save_preferences()
+    def _on_btn_save_clicked(self, _btn):
+        self._save_preferences()
+        self._changes = False
         self.btn_save.set_sensitive(False)
 
-    def close_ok(self):
-        self.save_preferences()
+    def _on_dialog_closed(self, *args):
+        self.emit("preferences-close", self._changes)
 
-    def load_preferences(self):
+    def _load_preferences(self):
         configuration = Configuration()
         first_time = configuration.get("first-time")
         version = configuration.get("version")
@@ -851,7 +743,7 @@ class PreferencesDialog(Gtk.Window):
         self.switch5.set_active(configuration.get("power-profile") == True)
         self.switch6.set_active(configuration.get("ac-notifications") == True)
 
-    def save_preferences(self):
+    def _save_preferences(self):
         configuration = Configuration()
         configuration.set("first-time", False)
         configuration.set("version", common.VERSION)
@@ -876,255 +768,156 @@ class PreferencesDialog(Gtk.Window):
         update_server_settings(settings)
 
 
-class SystemInfoDialog(Gtk.Dialog):
+# ---------------------------------------------------------------------------
+# SystemInfoDialog
+# ---------------------------------------------------------------------------
+
+class SystemInfoDialog(Adw.Window):
     def __init__(self, info):
-        Gtk.Dialog.__init__(
-            self,
-            _("Slimbook System information"),
-            None,
-            modal=True,
-            destroy_with_parent=True,
-            use_header_bar=True,
-        )
-
-        CSS = """
-            list {
-                border-width: 1px;
-                border-style: inset;
-                border-color: lightgrey;
-            }
-
-            row {
-                border-width: 1px;
-                border-style: outset;
-                border-color: lightgrey;
-                min-height: 32px;
-                min-width: 600px;
-            }
-            """
-        self.resize(800, 700)
+        super().__init__()
+        self.set_title(_("Slimbook System Information"))
+        self.set_default_size(700, 640)
+        self.set_modal(True)
         self.info = info
 
-        provider = Gtk.CssProvider()
-        provider.load_from_data(CSS.encode("utf-8"))
-        style_context = self.get_style_context()
-        style_context.add_provider_for_screen(
-            self.get_screen(), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
+        btn_copy = Gtk.Button.new_from_icon_name("edit-copy")
+        btn_copy.set_tooltip_text(_("Copy to Clipboard"))
+        btn_copy.connect("clicked", self._btn_copy_clicked)
 
-        # btn_copy = Gtk.Button(label=_("Copy"))
-        btn_copy = Gtk.Button.new_from_icon_name("edit-copy", Gtk.IconSize.BUTTON)
-        btn_copy.connect("clicked", self.btn_copy_clicked)
-        self.get_header_bar().pack_end(btn_copy)
+        header = Gtk.HeaderBar()
+        header.set_show_title_buttons(True)
+        header.pack_end(btn_copy)
 
-        scrw = Gtk.ScrolledWindow()
-        scrw.set_border_width(12)
-        listbox = Gtk.ListBox()
-        listbox.set_vexpand(True)
-        listbox.set_hexpand(True)
-
-        listbox.set_selection_mode(Gtk.SelectionMode.NONE)
-
-        scrw.add(listbox)
-        self.get_content_area().add(scrw)
-
+        group = Adw.PreferencesGroup()
         for k in info:
-            key = k[0]
-            value = k[1]
-            label_key = Gtk.Label(label=key)
-            # label_key.set_markup("<b>{0}</b>".format(key))
-            label_value = Gtk.Label(label=value)
+            key, value = k[0], k[1].strip()
+            row = Adw.ActionRow(title=key)
+            val_label = Gtk.Label(label=value)
+            val_label.add_css_class("dimmed")
+            val_label.set_selectable(True)
+            val_label.set_wrap(True)
+            val_label.set_hexpand(True)
+            val_label.set_halign(Gtk.Align.END)
+            val_label.set_valign(Gtk.Align.CENTER)
+            val_label.set_use_markup(False)
+            row.add_suffix(val_label)
+            group.add(row)
 
-            hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
+        page = Adw.PreferencesPage()
+        page.add(group)
 
+        self._toast_overlay = Adw.ToastOverlay()
+        self._toast_overlay.set_child(page)
 
-            hbox.pack_start(label_key, False, False, 1)
-            hbox.pack_end(label_value, False, False, 1)
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(self._toast_overlay)
+        self.set_content(toolbar_view)
 
-            row = Gtk.ListBoxRow()
-            row.add(hbox)
-
-            listbox.add(row)
-
-        self.show_all()
-
-    def btn_copy_clicked(self, button):
-        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-
-        txt = ""
-        for k in self.info:
-            key = k[0]
-            value = k[1]
-            txt = txt + "{0}:\t{1}\n".format(key, value)
-
-        clipboard.set_text(txt, -1)
-        button.set_sensitive(False)
+    def _btn_copy_clicked(self, button):
+        txt = "".join("{0}:\t{1}\n".format(k[0], k[1]) for k in self.info)
+        button.get_clipboard().set(txt)
+        self._toast_overlay.add_toast(Adw.Toast(title=_("Copied to clipboard")))
 
 
-class NotificationsDialog(Gtk.Window):
+# ---------------------------------------------------------------------------
+# NotificationsDialog
+# ---------------------------------------------------------------------------
+
+class NotificationsDialog(Adw.Window):
     def __init__(self, parent):
-        Gtk.Window.__init__(self)
+        super().__init__()
         self.set_modal(True)
-        self.parent = parent
         self.set_default_size(500, 600)
-
-        CSS = """
-            list {
-                border-width: 1px;
-                border-style: inset;
-                border-color: lightgrey;
-            }
-
-            row {
-                border-width: 1px;
-                border-style: outset;
-                border-color: lightgrey;
-                min-height: 32px;
-                min-width: 400px;
-            }
-            """
-
-        provider = Gtk.CssProvider()
-        provider.load_from_data(CSS.encode("utf-8"))
-        style_context = self.get_style_context()
-        style_context.add_provider_for_screen(
-            self.get_screen(), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
+        self.set_title(_("Slimbook Notifications"))
+        self.parent = parent
 
         parent.connect("feed-update-start", self.on_feed_update_start)
         parent.connect("feed-update-complete", self.on_feed_update_complete)
 
-        header = Gtk.HeaderBar()
-        header.set_title(_("Slimbook Notifications"))
-        header.set_show_close_button(True)
-
-        self.btn_refresh = Gtk.Button.new_with_label(_("Refresh"))
+        self.btn_refresh = Gtk.Button.new_from_icon_name("view-refresh-symbolic")
+        self.btn_refresh.set_tooltip_text(_("Refresh"))
         self.btn_refresh.connect("clicked", self.on_btn_refresh_clicked)
-        header.pack_end(self.btn_refresh)
 
-        self.set_titlebar(header)
+        header = Gtk.HeaderBar()
+        header.set_show_title_buttons(True)
+        header.pack_start(self.btn_refresh)
 
-        vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 12)
-        sw = Gtk.ScrolledWindow()
-        self.listbox = Gtk.ListBox()
+        self.toolbar_view = Adw.ToolbarView()
+        self.toolbar_view.add_top_bar(header)
+        self.set_content(self.toolbar_view)
 
-        self.listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._populate()
 
-        self.add(vbox)
-        sw.add(self.listbox)
-        vbox.pack_start(sw, True, True, 1)
-        vbox.set_border_width(16)
-
-        self.populate()
-
-        self.show_all()
-
-    def populate(self):
-        # feeds = check_news()
-        feeds = self.parent.check_news()
+    def _make_feeds_page(self, feeds):
+        group = Adw.PreferencesGroup()
 
         for feed in feeds:
-            grid = Gtk.Grid.new()
-            grid.set_row_spacing(4)
-            grid.set_column_spacing(8)
+            row = Adw.ActionRow(title=feed.title, subtitle=feed.body)
+            row.set_use_markup(False)
+            row.set_subtitle_lines(3)
 
-            lbl_title = Gtk.Label()
-            lbl_title.set_markup("<b>{0}</b>".format(feed.title))
-            lbl_title.set_halign(Gtk.Align.START)
+            icon = Gtk.Image.new_from_icon_name(feed.icon)
+            icon.set_pixel_size(32)
+            row.add_prefix(icon)
 
-            lbl_body = Gtk.Label(label=feed.body)
-            lbl_body.set_halign(Gtk.Align.START)
             if feed.link:
-                btn_link = Gtk.LinkButton(uri=feed.link, label=feed.link)
-                btn_link.set_halign(Gtk.Align.START)
-                grid.attach(btn_link, 1, 2, 1, 1)
+                row.set_activatable(True)
+                row.connect(
+                    "activated",
+                    lambda _row, url=feed.link: webbrowser.open(url),
+                )
+                row.set_tooltip_text(feed.link)
+                suffix = Gtk.Image.new_from_icon_name("adw-external-link-symbolic")
+                suffix.set_valign(Gtk.Align.CENTER)
+                row.add_suffix(suffix)
 
-            theme = Gtk.IconTheme()
-            pix = theme.load_icon(
-                icon_name=feed.icon, size=32, flags=Gtk.IconLookupFlags.FORCE_SYMBOLIC
+            group.add(row)
+
+        page = Adw.PreferencesPage()
+        page.add(group)
+        return page
+
+    def _make_status_page(self, icon_name, title, with_spinner=False):
+        status = Adw.StatusPage(icon_name="" if with_spinner else icon_name, title=title)
+        if with_spinner:
+            spinner = Adw.Spinner()
+            spinner.set_size_request(32, 32)
+            status.set_child(spinner)
+        return status
+
+    def _populate(self):
+        feeds = self.parent.check_news()
+        if feeds:
+            self.toolbar_view.set_content(self._make_feeds_page(feeds))
+        else:
+            self.toolbar_view.set_content(
+                self._make_status_page("face-plain-symbolic", _("Nothing to Show"))
             )
-
-            img = Gtk.Image.new_from_pixbuf(pix)
-
-            grid.attach(img, 0, 0, 1, 4)
-
-            grid.attach(lbl_title, 1, 0, 1, 1)
-            grid.attach(lbl_body, 1, 1, 1, 1)
-
-            row = Gtk.ListBoxRow()
-            row.add(grid)
-
-            self.listbox.add(row)
-
-        if len(feeds) == 0:
-            theme = Gtk.IconTheme()
-
-            pix = theme.load_icon(
-                icon_name="face-plain-symbolic",
-                size=32,
-                flags=Gtk.IconLookupFlags.FORCE_SYMBOLIC,
-            )
-
-            img = Gtk.Image.new_from_pixbuf(pix)
-            lbl = Gtk.Label(label=_("Nothing to show"))
-
-            grid = Gtk.Grid.new()
-            grid.set_row_spacing(4)
-            grid.set_column_spacing(8)
-            grid.attach(img, 0, 0, 1, 4)
-            grid.attach(lbl, 1, 1, 1, 1)
-
-            row = Gtk.ListBoxRow()
-            row.add(grid)
-
-            self.listbox.add(row)
-
-        self.listbox.show_all()
 
     def on_btn_refresh_clicked(self, widget):
         self.parent.update_feed()
-        self.show_feed_update()
+        self._show_feed_update()
 
     def on_feed_update_start(self, *args):
-        self.show_feed_update()
+        self._show_feed_update()
 
-    def show_feed_update(self):
+    def _show_feed_update(self):
         self.btn_refresh.set_sensitive(False)
-        children = self.listbox.get_children()
-        for child in children:
-            self.listbox.remove(child)
-
-        theme = Gtk.IconTheme()
-
-        pix = theme.load_icon(
-            icon_name="emblem-synchronizing-symbolic",
-            size=32,
-            flags=Gtk.IconLookupFlags.FORCE_SYMBOLIC,
+        self.toolbar_view.set_content(
+            self._make_status_page(
+                "emblem-synchronizing-symbolic", _("Fetching…"), with_spinner=True
+            )
         )
-
-        img = Gtk.Image.new_from_pixbuf(pix)
-        lbl = Gtk.Label(label=_("Fetching..."))
-
-        grid = Gtk.Grid.new()
-        grid.set_row_spacing(4)
-        grid.set_column_spacing(8)
-        grid.attach(img, 0, 0, 1, 4)
-        grid.attach(lbl, 1, 1, 1, 1)
-
-        row = Gtk.ListBoxRow()
-        row.add(grid)
-
-        self.listbox.add(row)
-        self.listbox.show_all()
 
     def on_feed_update_complete(self, *args):
         self.btn_refresh.set_sensitive(True)
-        children = self.listbox.get_children()
+        self._populate()
 
-        for child in children:
-            self.listbox.remove(child)
-        self.populate()
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def manage_autostart(create):
     if not os.path.exists(common.AUTOSTART_DIR):
@@ -1137,11 +930,16 @@ def manage_autostart(create):
             os.remove(common.FILE_AUTO_START)
 
 
+# ---------------------------------------------------------------------------
+# Single-instance / main-loop management
+# ---------------------------------------------------------------------------
+
 PID_FILE = os.path.join(
     os.environ.get("XDG_RUNTIME_DIR", "/tmp"), "slimbook-service-indicator.pid"
 )
 
 _indicator_instance = None
+_main_loop = None
 
 
 def _on_sigusr1(*args):
@@ -1170,7 +968,7 @@ def send_preferences_signal():
 
 
 def init_indicator():
-    global _indicator_instance
+    global _indicator_instance, _main_loop
     try:
         _indicator_instance = ServiceIndicator()
 
@@ -1178,7 +976,8 @@ def init_indicator():
             f.write(str(os.getpid()))
 
         signal.signal(signal.SIGUSR1, _on_sigusr1)
-        GLib.MainLoop().run()
+        _main_loop = GLib.MainLoop()
+        _main_loop.run()
     except KeyboardInterrupt:
         logging.info("out of main loop")
     finally:

--- a/slimbook/usr/share/slimbook/locale-langpack/ast/LC_MESSAGES/slimbook.po
+++ b/slimbook/usr/share/slimbook/locale-langpack/ast/LC_MESSAGES/slimbook.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-18 15:11+0200\n"
+"POT-Creation-Date: 2026-06-28 16:05+0200\n"
 "PO-Revision-Date: 2025-11-17 23:04+0100\n"
 "Last-Translator: Mikel González (Softastur) <mikelglez@softastur.org>\n"
 "Language-Team: \n"
@@ -18,320 +18,369 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#: client.py:76
-msgid "Slimbok Client Notifications"
-msgstr "Avisos pal veceru/a de Slimbook"
-
-#: client.py:426
+#: client.py:386
 msgid "Notifications"
 msgstr "Avisos"
 
-#: client.py:431
-msgid "System information"
+#: client.py:391
+#, fuzzy
+msgid "System Information"
 msgstr "Información del sistema"
 
-#: client.py:436
+#: client.py:395
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: client.py:445
+#: client.py:403
+msgid "Control Panel"
+msgstr ""
+
+#: client.py:411
 msgid "About"
 msgstr "Tocante a"
 
-#: client.py:450 client.py:590
-msgid "Generate report"
+#: client.py:415 client.py:554 client.py:566
+#, fuzzy
+msgid "Generate Report"
 msgstr "Xenerar un informe"
 
-#: client.py:456
-msgid "Report a bug..."
+#: client.py:420
+#, fuzzy
+msgid "Report a Bug…"
 msgstr "Avisar d'un fallu..."
 
-#: client.py:467
+#: client.py:430
 msgid "Exit"
 msgstr "Colar"
 
-#: client.py:483 common.py:129
+#: client.py:494 common.py:218
 msgid "Slimbook Service"
 msgstr "Seviciu de Slimbook"
 
-#: client.py:496
-msgid "Visit Website"
-msgstr "Visitar el sitiu web"
-
-#: client.py:498
-msgid "Report issue"
-msgstr "Avisar d'un problema"
-
-#: client.py:505
-msgid "translation-credits"
+#: client.py:500
+#, fuzzy
+msgid "translator-credits"
 msgstr "Softastur.org"
 
-#: client.py:612
+#: client.py:568
 msgid ""
-"This is a report of several hardware and software stats.\n"
-"Full report generates a report with sensitive information,\n"
-"beware of sharing it online!"
+"Creates a compressed archive with hardware and software information. The "
+"full report also includes sensitive data such as MAC address and board "
+"serial number"
 msgstr ""
-"Esto ye un informe que contién información y estadístiques del equipu.\n"
-"L'informe complentu inclúi datos delicaos,\n"
-"pon procuru si pienses compartilu en llínia!"
 
-#: client.py:622
+#: client.py:572
 msgid "Report"
 msgstr "Informe"
 
-#: client.py:625
-msgid "Full report"
+#: client.py:575
+#, fuzzy
+msgid "Full Report"
 msgstr "Informe completu"
 
-#: client.py:649
-msgid "Open"
-msgstr "Abrir"
+#: client.py:584
+msgid "Generating…"
+msgstr ""
 
-#: client.py:652 client.py:679
+#: client.py:591
+msgid "Open Folder"
+msgstr ""
+
+#: client.py:600
 msgid "Close"
 msgstr "Zarrar"
 
-#: client.py:698
-msgid "Succesful! Dumped at "
-msgstr "Xeneróse correutamente en "
-
-#: client.py:706
-msgid ""
-"Error! Report wasn't able to be generated\n"
-"Error: "
+#: client.py:620
+msgid "Error"
 msgstr ""
-"Hebo un fallu al xenerar l'informe\n"
-"Fallu: "
 
-#: client.py:762
+#: client.py:622
+msgid "The report could not be generated:\n"
+msgstr ""
+
+#: client.py:627
+msgid "Report Generated"
+msgstr ""
+
+#: client.py:628
+#, fuzzy
+msgid "Saved at "
+msgstr "Guardar"
+
+#: client.py:677
+#, fuzzy
+msgid "Show Indicator"
+msgstr "Amosar un indicador"
+
+#: client.py:678
+msgid "Autostart"
+msgstr "Aniciar automáticamente"
+
+#: client.py:679
+#, fuzzy
+msgid "Light-Mode Icon"
+msgstr "Iconu claru"
+
+#: client.py:680
+msgid "Check Notifications"
+msgstr "Comprobar avisos"
+
+#: client.py:681
+#, fuzzy
+msgid "Trackpad Lock"
+msgstr "Torgar el trackpad"
+
+#: client.py:682
+#, fuzzy
+msgid "Set Power Profile"
+msgstr "Afitar el perfil de rindimientu"
+
+#: client.py:683
+msgid "AC Notifications"
+msgstr "Notificaciones AC"
+
+#: client.py:688
 msgid "Slimbook Preferences"
 msgstr "Preferencies de Slimbook"
 
-#: client.py:765
+#: client.py:703
 msgid "Save"
 msgstr "Guardar"
 
 #: client.py:777
-msgid "Show indicator"
-msgstr "Amosar un indicador"
-
-#: client.py:784
-msgid "Autostart"
-msgstr "Aniciar automáticamente"
-
-#: client.py:791
-msgid "Light-mode Icon"
-msgstr "Iconu claru"
-
-#: client.py:798
-msgid "Check Notifications"
-msgstr "Comprobar avisos"
-
-#: client.py:805
-msgid "Trackpad lock"
-msgstr "Torgar el trackpad"
-
-#: client.py:812
-msgid "Set power profile"
-msgstr "Afitar el perfil de rindimientu"
-
-#: client.py:818
-msgid "AC Notifications"
-msgstr "Notificaciones AC"
-
-#: client.py:887
-msgid "Slimbook System information"
+#, fuzzy
+msgid "Slimbook System Information"
 msgstr "Información del sistema de Slimbook"
 
-#: client.py:1003
+#: client.py:783
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: client.py:820
+msgid "Copied to clipboard"
+msgstr ""
+
+#: client.py:832
 msgid "Slimbook Notifications"
 msgstr "Avisos de Slimbook"
 
-#: client.py:1006
+#: client.py:839
 msgid "Refresh"
 msgstr "Volver a cargar"
 
-#: client.py:1069
-msgid "Nothing to show"
+#: client.py:896
+#, fuzzy
+msgid "Nothing to Show"
 msgstr "Nun hai nada"
 
-#: client.py:1105
-msgid "Fetching..."
+#: client.py:910
+#, fuzzy
+msgid "Fetching…"
 msgstr "Cargando..."
 
-#: common.py:69
+#: common.py:86 common.py:113
 msgid "Silent Mode enabled"
 msgstr "Habilitóse'l mou silenciosu"
 
-#: common.py:70
+#: common.py:87 common.py:114
 msgid "Silent Mode disabled"
 msgstr "Deshabilitóse'l mou silenciosu"
 
-#: common.py:71
+#: common.py:88 common.py:115
 msgid "Silent Mode changed"
 msgstr "El mou silenciosu cambió"
 
-#: common.py:73
+#: common.py:90 common.py:117
 msgid "Super Key Lock enabled"
 msgstr "Habilitose la torga de la tecla \"super\""
 
-#: common.py:74
+#: common.py:91 common.py:118
 msgid "Super Key Lock disabled"
 msgstr "Deshabilitóse la torga de la tecla \"super\""
 
-#: common.py:75
+#: common.py:92 common.py:119
 msgid "Super Key Lock changed"
 msgstr "La torga de la tecla \"super\" cambió"
 
-#: common.py:77 common.py:188
+#: common.py:94 common.py:121 common.py:278
 msgid "Silent Mode"
 msgstr "Mou silenciosu"
 
-#: common.py:78
+#: common.py:95 common.py:122
 msgid "Normal Mode"
 msgstr "Mou normal"
 
-#: common.py:79
+#: common.py:96 common.py:123
 msgid "Performance Mode"
 msgstr "Mou de rindimientu altu"
 
-#: common.py:80
+#: common.py:97 common.py:124
 msgid "Dynamic Mode"
 msgstr "Mou dinámicu"
 
-#: common.py:82
+#: common.py:99 common.py:126
 msgid "Touchpad enabled"
 msgstr "Habilitóse'l panel táctil"
 
-#: common.py:83
+#: common.py:100 common.py:127
 msgid "Touchpad disabled"
 msgstr "Deshabilitóse'l panel táctil"
 
-#: common.py:84
+#: common.py:101 common.py:128
 msgid "Touchpad changed"
 msgstr "El panel táctil cambió"
 
-#: common.py:85
+#: common.py:102 common.py:129
 msgid "Webcam changed"
 msgstr "La cámara web cambió"
 
-#: common.py:86
+#: common.py:103 common.py:130
 msgid "Webcam enabled"
 msgstr "Habilitóse la cámara web"
 
-#: common.py:87
+#: common.py:104 common.py:131
 msgid "Webcam disabled"
 msgstr "Deshabilitóse la cámara web"
 
-#: common.py:89
+#: common.py:106 common.py:133
 msgid "Energy Saver"
 msgstr "Aforrador d'enerxía"
 
-#: common.py:90
+#: common.py:107 common.py:134
 msgid "Balanced"
 msgstr "Equilibráu"
 
-#: common.py:91
+#: common.py:108 common.py:135
 msgid "Performance"
 msgstr "Rindimientu"
 
-#: common.py:167
+#: common.py:257
 msgid "Uptime"
 msgstr "Tiempu enceso"
 
-#: common.py:168
+#: common.py:258
 msgid "Memory Free/Total"
 msgstr "Memoria llibre/total"
 
-#: common.py:169
+#: common.py:259
 msgid "Memory device"
 msgstr "Preséu de memoria"
 
-#: common.py:170
+#: common.py:260
 msgid "UMA"
 msgstr "UMA"
 
-#: common.py:171
+#: common.py:261
 msgid "Disk Free/Total"
 msgstr "Espaciu en discu llibre / total"
 
-#: common.py:172
+#: common.py:262
 msgid "Kernel"
 msgstr "Nucleu"
 
-#: common.py:173
+#: common.py:263
 msgid "OS"
 msgstr "Sistema operativu"
 
-#: common.py:174
+#: common.py:264
 msgid "Desktop"
 msgstr "Escritoriu"
 
-#: common.py:175
+#: common.py:265
 msgid "Session"
 msgstr "Sesión"
 
-#: common.py:176
+#: common.py:266
 msgid "Product"
 msgstr "Productu"
 
-#: common.py:177
+#: common.py:267
 msgid "Serial"
 msgstr "Númberu de serie"
 
-#: common.py:178
+#: common.py:268
 msgid "Bios Version"
 msgstr "Versión de la bios"
 
-#: common.py:179
+#: common.py:269
 msgid "EC Version"
 msgstr "Versión de la EC"
 
-#: common.py:180
+#: common.py:270
 msgid "Boot Mode"
 msgstr "Mou d'arranque"
 
-#: common.py:181
+#: common.py:271
 msgid "Secure Boot"
 msgstr "Arranque seguru"
 
-#: common.py:182
+#: common.py:272
 msgid "CPU"
 msgstr "CPU"
 
-#: common.py:183
+#: common.py:273
 msgid "TDP"
 msgstr "TDP"
 
-#: common.py:184
+#: common.py:274
 msgid "GPU"
 msgstr "GPU"
 
-#: common.py:185
+#: common.py:275
 msgid "Module loaded"
 msgstr "Módulu cargáu"
 
-#: common.py:186
+#: common.py:276
 msgid "Fn Lock"
 msgstr "Torga de la tecla \"fn\""
 
-#: common.py:187
+#: common.py:277
 msgid "Super Lock"
 msgstr "Torga de la tecla \"super\""
 
-#: common.py:189
+#: common.py:279
 msgid "Turbo Mode"
 msgstr "Mou turbu"
 
-#: common.py:190
+#: common.py:280
 msgid "Profile"
 msgstr "Perfil"
 
-#: common.py:192
+#: common.py:282
 msgid "Yes"
 msgstr "Sí"
 
-#: common.py:193
+#: common.py:283
 msgid "No"
 msgstr "Non"
+
+#~ msgid "Slimbok Client Notifications"
+#~ msgstr "Avisos pal veceru/a de Slimbook"
+
+#~ msgid "Visit Website"
+#~ msgstr "Visitar el sitiu web"
+
+#~ msgid "Report issue"
+#~ msgstr "Avisar d'un problema"
+
+#~ msgid ""
+#~ "This is a report of several hardware and software stats.\n"
+#~ "Full report generates a report with sensitive information,\n"
+#~ "beware of sharing it online!"
+#~ msgstr ""
+#~ "Esto ye un informe que contién información y estadístiques del equipu.\n"
+#~ "L'informe complentu inclúi datos delicaos,\n"
+#~ "pon procuru si pienses compartilu en llínia!"
+
+#~ msgid "Open"
+#~ msgstr "Abrir"
+
+#~ msgid "Succesful! Dumped at "
+#~ msgstr "Xeneróse correutamente en "
+
+#~ msgid ""
+#~ "Error! Report wasn't able to be generated\n"
+#~ "Error: "
+#~ msgstr ""
+#~ "Hebo un fallu al xenerar l'informe\n"
+#~ "Fallu: "

--- a/slimbook/usr/share/slimbook/locale-langpack/ca/LC_MESSAGES/slimbook.po
+++ b/slimbook/usr/share/slimbook/locale-langpack/ca/LC_MESSAGES/slimbook.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-18 15:11+0200\n"
+"POT-Creation-Date: 2026-06-28 16:05+0200\n"
 "PO-Revision-Date: 2025-09-25 14:18+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,320 +18,369 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#: client.py:76
-msgid "Slimbok Client Notifications"
-msgstr "Notificacions del client Slimbook"
-
-#: client.py:426
+#: client.py:386
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: client.py:431
-msgid "System information"
+#: client.py:391
+#, fuzzy
+msgid "System Information"
 msgstr "Informació del sistema"
 
-#: client.py:436
+#: client.py:395
 msgid "Preferences"
 msgstr "Paràmetres"
 
-#: client.py:445
+#: client.py:403
+msgid "Control Panel"
+msgstr ""
+
+#: client.py:411
 msgid "About"
 msgstr "Quant a"
 
-#: client.py:450 client.py:590
-msgid "Generate report"
+#: client.py:415 client.py:554 client.py:566
+#, fuzzy
+msgid "Generate Report"
 msgstr "Genera un informe"
 
-#: client.py:456
-msgid "Report a bug..."
+#: client.py:420
+#, fuzzy
+msgid "Report a Bug…"
 msgstr "Informa d'un error…"
 
-#: client.py:467
+#: client.py:430
 msgid "Exit"
 msgstr "Surt"
 
-#: client.py:483 common.py:129
+#: client.py:494 common.py:218
 msgid "Slimbook Service"
 msgstr "Servei Slimbook"
 
-#: client.py:496
-msgid "Visit Website"
-msgstr "Visita el lloc web"
-
-#: client.py:498
-msgid "Report issue"
-msgstr "Informa d'un problema"
-
-#: client.py:505
-msgid "translation-credits"
+#: client.py:500
+#, fuzzy
+msgid "translator-credits"
 msgstr "Víctor Rodríguez"
 
-#: client.py:612
+#: client.py:568
 msgid ""
-"This is a report of several hardware and software stats.\n"
-"Full report generates a report with sensitive information,\n"
-"beware of sharing it online!"
+"Creates a compressed archive with hardware and software information. The "
+"full report also includes sensitive data such as MAC address and board "
+"serial number"
 msgstr ""
-"Això és un informe amb diverses estadístiques de maquinari i programari.\n"
-"L'informe complet genera un informe amb informació sensible,\n"
-"aneu amb compte a l'hora de compartir-lo en línia!"
 
-#: client.py:622
+#: client.py:572
 msgid "Report"
 msgstr "Informa"
 
-#: client.py:625
-msgid "Full report"
+#: client.py:575
+#, fuzzy
+msgid "Full Report"
 msgstr "Informe complet"
 
-#: client.py:649
-msgid "Open"
-msgstr "Obre"
+#: client.py:584
+msgid "Generating…"
+msgstr ""
 
-#: client.py:652 client.py:679
+#: client.py:591
+msgid "Open Folder"
+msgstr ""
+
+#: client.py:600
 msgid "Close"
 msgstr "Tanca"
 
-#: client.py:698
-msgid "Succesful! Dumped at "
-msgstr "Èxit! S'ha generat a "
-
-#: client.py:706
-msgid ""
-"Error! Report wasn't able to be generated\n"
-"Error: "
+#: client.py:620
+msgid "Error"
 msgstr ""
-"S'ha produït un error! No s'ha pogut generar l'informe\n"
-"Error: "
 
-#: client.py:762
+#: client.py:622
+msgid "The report could not be generated:\n"
+msgstr ""
+
+#: client.py:627
+msgid "Report Generated"
+msgstr ""
+
+#: client.py:628
+#, fuzzy
+msgid "Saved at "
+msgstr "Desa"
+
+#: client.py:677
+#, fuzzy
+msgid "Show Indicator"
+msgstr "Mostra l'indicador"
+
+#: client.py:678
+msgid "Autostart"
+msgstr "Inici automàtic"
+
+#: client.py:679
+#, fuzzy
+msgid "Light-Mode Icon"
+msgstr "Icona en mode clar"
+
+#: client.py:680
+msgid "Check Notifications"
+msgstr "Comprova les notificacions"
+
+#: client.py:681
+#, fuzzy
+msgid "Trackpad Lock"
+msgstr "Bloqueig del trackpad"
+
+#: client.py:682
+#, fuzzy
+msgid "Set Power Profile"
+msgstr "Estableix el perfil de rendiment"
+
+#: client.py:683
+msgid "AC Notifications"
+msgstr "Notificacions AC"
+
+#: client.py:688
 msgid "Slimbook Preferences"
 msgstr "Paràmetres de Slimbook"
 
-#: client.py:765
+#: client.py:703
 msgid "Save"
 msgstr "Desa"
 
 #: client.py:777
-msgid "Show indicator"
-msgstr "Mostra l'indicador"
-
-#: client.py:784
-msgid "Autostart"
-msgstr "Inici automàtic"
-
-#: client.py:791
-msgid "Light-mode Icon"
-msgstr "Icona en mode clar"
-
-#: client.py:798
-msgid "Check Notifications"
-msgstr "Comprova les notificacions"
-
-#: client.py:805
-msgid "Trackpad lock"
-msgstr "Bloqueig del trackpad"
-
-#: client.py:812
-msgid "Set power profile"
-msgstr "Estableix el perfil de rendiment"
-
-#: client.py:818
-msgid "AC Notifications"
-msgstr "Notificacions AC"
-
-#: client.py:887
-msgid "Slimbook System information"
+#, fuzzy
+msgid "Slimbook System Information"
 msgstr "Informació del sistema de Slimbook"
 
-#: client.py:1003
+#: client.py:783
+msgid "Copy to Clipboard"
+msgstr ""
+
+#: client.py:820
+msgid "Copied to clipboard"
+msgstr ""
+
+#: client.py:832
 msgid "Slimbook Notifications"
 msgstr "Notificacions de Slimbook"
 
-#: client.py:1006
+#: client.py:839
 msgid "Refresh"
 msgstr "Actualitza"
 
-#: client.py:1069
-msgid "Nothing to show"
+#: client.py:896
+#, fuzzy
+msgid "Nothing to Show"
 msgstr "Res a mostrar"
 
-#: client.py:1105
-msgid "Fetching..."
+#: client.py:910
+#, fuzzy
+msgid "Fetching…"
 msgstr "S'està carregant…"
 
-#: common.py:69
+#: common.py:86 common.py:113
 msgid "Silent Mode enabled"
 msgstr "S'ha activat el mode silenciós"
 
-#: common.py:70
+#: common.py:87 common.py:114
 msgid "Silent Mode disabled"
 msgstr "S'ha desactivat el mode silenciós"
 
-#: common.py:71
+#: common.py:88 common.py:115
 msgid "Silent Mode changed"
 msgstr "Ha canviat el mode silenciós"
 
-#: common.py:73
+#: common.py:90 common.py:117
 msgid "Super Key Lock enabled"
 msgstr "S'ha activat el bloqueig amb la tecla «Super»"
 
-#: common.py:74
+#: common.py:91 common.py:118
 msgid "Super Key Lock disabled"
 msgstr "S'ha desactivat el bloqueig amb la tecla «Super»"
 
-#: common.py:75
+#: common.py:92 common.py:119
 msgid "Super Key Lock changed"
 msgstr "El bloqueig amb la tecla «Super» ha canviat"
 
-#: common.py:77 common.py:188
+#: common.py:94 common.py:121 common.py:278
 msgid "Silent Mode"
 msgstr "Mode silenciós"
 
-#: common.py:78
+#: common.py:95 common.py:122
 msgid "Normal Mode"
 msgstr "Mode normal"
 
-#: common.py:79
+#: common.py:96 common.py:123
 msgid "Performance Mode"
 msgstr "Mode d'alt rendiment"
 
-#: common.py:80
+#: common.py:97 common.py:124
 msgid "Dynamic Mode"
 msgstr "Mode dinàmic"
 
-#: common.py:82
+#: common.py:99 common.py:126
 msgid "Touchpad enabled"
 msgstr "S'ha activat el touchpad"
 
-#: common.py:83
+#: common.py:100 common.py:127
 msgid "Touchpad disabled"
 msgstr "S'ha desactivat el touchpad"
 
-#: common.py:84
+#: common.py:101 common.py:128
 msgid "Touchpad changed"
 msgstr "El touchpad ha canviat"
 
-#: common.py:85
+#: common.py:102 common.py:129
 msgid "Webcam changed"
 msgstr "La càmera web ha canviat"
 
-#: common.py:86
+#: common.py:103 common.py:130
 msgid "Webcam enabled"
 msgstr "S'ha activat la càmera web"
 
-#: common.py:87
+#: common.py:104 common.py:131
 msgid "Webcam disabled"
 msgstr "S'ha desactivat la càmera web"
 
-#: common.py:89
+#: common.py:106 common.py:133
 msgid "Energy Saver"
 msgstr "Estalvi d'energia"
 
-#: common.py:90
+#: common.py:107 common.py:134
 msgid "Balanced"
 msgstr "Equilibrat"
 
-#: common.py:91
+#: common.py:108 common.py:135
 msgid "Performance"
 msgstr "Rendiment"
 
-#: common.py:167
+#: common.py:257
 msgid "Uptime"
 msgstr "Temps en funcionament"
 
-#: common.py:168
+#: common.py:258
 msgid "Memory Free/Total"
 msgstr "Memòria lliure/total"
 
-#: common.py:169
+#: common.py:259
 msgid "Memory device"
 msgstr "Dispositiu de memòria"
 
-#: common.py:170
+#: common.py:260
 msgid "UMA"
 msgstr "UMA"
 
-#: common.py:171
+#: common.py:261
 msgid "Disk Free/Total"
 msgstr "Espai de disc lliure/total"
 
-#: common.py:172
+#: common.py:262
 msgid "Kernel"
 msgstr "Nucli"
 
-#: common.py:173
+#: common.py:263
 msgid "OS"
 msgstr "Sistema operatiu"
 
-#: common.py:174
+#: common.py:264
 msgid "Desktop"
 msgstr "Escriptori"
 
-#: common.py:175
+#: common.py:265
 msgid "Session"
 msgstr "Sessió"
 
-#: common.py:176
+#: common.py:266
 msgid "Product"
 msgstr "Producte"
 
-#: common.py:177
+#: common.py:267
 msgid "Serial"
 msgstr "Número de sèrie"
 
-#: common.py:178
+#: common.py:268
 msgid "Bios Version"
 msgstr "Versió de la Bios"
 
-#: common.py:179
+#: common.py:269
 msgid "EC Version"
 msgstr "Versió de l'EC"
 
-#: common.py:180
+#: common.py:270
 msgid "Boot Mode"
 msgstr "Mode d'arrancada"
 
-#: common.py:181
+#: common.py:271
 msgid "Secure Boot"
 msgstr "Arrencada segura"
 
-#: common.py:182
+#: common.py:272
 msgid "CPU"
 msgstr "CPU"
 
-#: common.py:183
+#: common.py:273
 msgid "TDP"
 msgstr "TDP"
 
-#: common.py:184
+#: common.py:274
 msgid "GPU"
 msgstr "GPU"
 
-#: common.py:185
+#: common.py:275
 msgid "Module loaded"
 msgstr "S'ha carregat el mòdul"
 
-#: common.py:186
+#: common.py:276
 msgid "Fn Lock"
 msgstr "Bloqueja amb «Fn»"
 
-#: common.py:187
+#: common.py:277
 msgid "Super Lock"
 msgstr "Bloqueja amb «Super»"
 
-#: common.py:189
+#: common.py:279
 msgid "Turbo Mode"
 msgstr "Mode turbo"
 
-#: common.py:190
+#: common.py:280
 msgid "Profile"
 msgstr "Perfil"
 
-#: common.py:192
+#: common.py:282
 msgid "Yes"
 msgstr "Sí"
 
-#: common.py:193
+#: common.py:283
 msgid "No"
 msgstr "No"
+
+#~ msgid "Slimbok Client Notifications"
+#~ msgstr "Notificacions del client Slimbook"
+
+#~ msgid "Visit Website"
+#~ msgstr "Visita el lloc web"
+
+#~ msgid "Report issue"
+#~ msgstr "Informa d'un problema"
+
+#~ msgid ""
+#~ "This is a report of several hardware and software stats.\n"
+#~ "Full report generates a report with sensitive information,\n"
+#~ "beware of sharing it online!"
+#~ msgstr ""
+#~ "Això és un informe amb diverses estadístiques de maquinari i programari.\n"
+#~ "L'informe complet genera un informe amb informació sensible,\n"
+#~ "aneu amb compte a l'hora de compartir-lo en línia!"
+
+#~ msgid "Open"
+#~ msgstr "Obre"
+
+#~ msgid "Succesful! Dumped at "
+#~ msgstr "Èxit! S'ha generat a "
+
+#~ msgid ""
+#~ "Error! Report wasn't able to be generated\n"
+#~ "Error: "
+#~ msgstr ""
+#~ "S'ha produït un error! No s'ha pogut generar l'informe\n"
+#~ "Error: "

--- a/slimbook/usr/share/slimbook/locale-langpack/es/LC_MESSAGES/slimbook.po
+++ b/slimbook/usr/share/slimbook/locale-langpack/es/LC_MESSAGES/slimbook.po
@@ -2,336 +2,376 @@
 # Copyright (C) 2025 Slimbook
 # This file is distributed under the same license.
 # Slimbook, 2025.
+# Óscar Fernández Díaz <oscfdezdz@tuta.io>, 2026.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: unnamed project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-18 15:11+0200\n"
-"PO-Revision-Date: 2025-09-25 14:18+0200\n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Language: es_ES\n"
+"POT-Creation-Date: 2026-06-28 16:05+0200\n"
+"PO-Revision-Date: 2026-07-02 17:38+0200\n"
+"Last-Translator: Óscar Fernández Díaz <oscfdezdz@tuta.io>\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.6\n"
+"X-Generator: Gtranslator 50.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: client.py:76
-msgid "Slimbok Client Notifications"
-msgstr "Notificaciones del cliente Slimbook"
-
-#: client.py:426
+#: client.py:386
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: client.py:431
-msgid "System information"
+#: client.py:391
+msgid "System Information"
 msgstr "Información del sistema"
 
-#: client.py:436
+#: client.py:395
 msgid "Preferences"
 msgstr "Parámetros"
 
-#: client.py:445
+#: client.py:403
+msgid "Control Panel"
+msgstr "Panel de control"
+
+#: client.py:411
 msgid "About"
 msgstr "Acerca de"
 
-#: client.py:450 client.py:590
-msgid "Generate report"
+#: client.py:415 client.py:554 client.py:566
+msgid "Generate Report"
 msgstr "Generar un informe"
 
-#: client.py:456
-msgid "Report a bug..."
+#: client.py:420
+msgid "Report a Bug…"
 msgstr "Informar de un error…"
 
-#: client.py:467
+#: client.py:430
 msgid "Exit"
 msgstr "Salir"
 
-#: client.py:483 common.py:129
+#: client.py:494 common.py:218
 msgid "Slimbook Service"
 msgstr "Servicio Slimbook"
 
-#: client.py:496
-msgid "Visit Website"
-msgstr "Visita la página web"
-
-#: client.py:498
-msgid "Report issue"
-msgstr "Informar de un problema"
-
-#: client.py:505
-msgid "translation-credits"
+#: client.py:500
+msgid "translator-credits"
 msgstr "Slimbook"
 
-#: client.py:612
+#: client.py:568
 msgid ""
-"This is a report of several hardware and software stats.\n"
-"Full report generates a report with sensitive information,\n"
-"beware of sharing it online!"
+"Creates a compressed archive with hardware and software information. The "
+"full report also includes sensitive data such as MAC address and board "
+"serial number"
 msgstr ""
-"Esto es un informe que contiene información y estadísticas del equipo.\n"
-"El informe completo genera un informe con datos sensibles,\n"
-"id con cuidado a la hora de compartirlo en linea"
+"Crea un archivo comprimido con información sobre el hardware y el software. "
+"El informe completo también incluye datos sensibles, como la dirección MAC y "
+"el número de serie de la placa."
 
-#: client.py:622
+#: client.py:572
 msgid "Report"
-msgstr "Informar"
+msgstr "Informe"
 
-#: client.py:625
-msgid "Full report"
+#: client.py:575
+msgid "Full Report"
 msgstr "Informe completo"
 
-#: client.py:649
-msgid "Open"
-msgstr "Abrir"
+#: client.py:584
+msgid "Generating…"
+msgstr "Generando…"
 
-#: client.py:652 client.py:679
+#: client.py:591
+msgid "Open Folder"
+msgstr "Abrir carpeta"
+
+#: client.py:600
 msgid "Close"
 msgstr "Cerrar"
 
-#: client.py:698
-msgid "Succesful! Dumped at "
-msgstr "¡Éxito! Se ha generado:"
+#: client.py:620
+msgid "Error"
+msgstr "Error"
 
-#: client.py:706
-msgid ""
-"Error! Report wasn't able to be generated\n"
-"Error: "
-msgstr ""
-"Se ha producido un error y el informe no se ha generado\n"
-"Error: "
+#: client.py:622
+msgid "The report could not be generated:\n"
+msgstr "El informe no ha podido generarse:\n"
 
-#: client.py:762
+#: client.py:627
+msgid "Report Generated"
+msgstr "Informe generado"
+
+#: client.py:628
+msgid "Saved at "
+msgstr "Guardado en"
+
+#: client.py:677
+msgid "Show Indicator"
+msgstr "Mostra el indicador"
+
+#: client.py:678
+msgid "Autostart"
+msgstr "Inicio automático"
+
+#: client.py:679
+msgid "Light-Mode Icon"
+msgstr "Icono en modo claro"
+
+#: client.py:680
+msgid "Check Notifications"
+msgstr "Comprobar las notificaciones"
+
+#: client.py:681
+msgid "Trackpad Lock"
+msgstr "Bloqueo del panel táctil"
+
+#: client.py:682
+msgid "Set Power Profile"
+msgstr "Establecer el perfil de rendimiento"
+
+#: client.py:683
+msgid "AC Notifications"
+msgstr "Notificaciones AC"
+
+#: client.py:688
 msgid "Slimbook Preferences"
 msgstr "Parámetros de Slimbook"
 
-#: client.py:765
+#: client.py:703
 msgid "Save"
 msgstr "Guardar"
 
 #: client.py:777
-msgid "Show indicator"
-msgstr "Mostra el indicador"
-
-#: client.py:784
-msgid "Autostart"
-msgstr "Inicio automático"
-
-#: client.py:791
-msgid "Light-mode Icon"
-msgstr "Icono en modo claro"
-
-#: client.py:798
-msgid "Check Notifications"
-msgstr "Comprueba las notificaciones"
-
-#: client.py:805
-msgid "Trackpad lock"
-msgstr "Bloqueo del trackpad"
-
-#: client.py:812
-msgid "Set power profile"
-msgstr "Establece el perfil de rendimiento"
-
-#: client.py:818
-msgid "AC Notifications"
-msgstr "Notificaciones AC"
-
-#: client.py:887
-msgid "Slimbook System information"
+msgid "Slimbook System Information"
 msgstr "Información del sistema de Slimbook"
 
-#: client.py:1003
+#: client.py:783
+msgid "Copy to Clipboard"
+msgstr "Copiar al portapapeles"
+
+#: client.py:820
+msgid "Copied to clipboard"
+msgstr "Copiado al portapapeles"
+
+#: client.py:832
 msgid "Slimbook Notifications"
 msgstr "Notificaciones de Slimbook"
 
-#: client.py:1006
+#: client.py:839
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: client.py:1069
-msgid "Nothing to show"
+#: client.py:896
+msgid "Nothing to Show"
 msgstr "Nada que mostrar"
 
-#: client.py:1105
-msgid "Fetching..."
+#: client.py:910
+msgid "Fetching…"
 msgstr "Cargando…"
 
-#: common.py:69
+#: common.py:86 common.py:113
 msgid "Silent Mode enabled"
-msgstr "Modo Silencioso activado"
+msgstr "Modo silencioso activado"
 
-#: common.py:70
+#: common.py:87 common.py:114
 msgid "Silent Mode disabled"
-msgstr "Modo Silencioso desactivado"
+msgstr "Modo silencioso desactivado"
 
-#: common.py:71
+#: common.py:88 common.py:115
 msgid "Silent Mode changed"
-msgstr "Modo Silencioso ha cambiado"
+msgstr "Modo silencioso ha cambiado"
 
-#: common.py:73
+#: common.py:90 common.py:117
 msgid "Super Key Lock enabled"
 msgstr "Bloqueo de la tecla «Super» activado"
 
-#: common.py:74
+#: common.py:91 common.py:118
 msgid "Super Key Lock disabled"
 msgstr "Bloqueo de la tecla «Super» desactivado"
 
-#: common.py:75
+#: common.py:92 common.py:119
 msgid "Super Key Lock changed"
 msgstr "Bloqueo de la tecla «Super» ha cambiado"
 
-#: common.py:77 common.py:188
+#: common.py:94 common.py:121 common.py:278
 msgid "Silent Mode"
-msgstr "Modo Silencioso"
+msgstr "Modo silencioso"
 
-#: common.py:78
+#: common.py:95 common.py:122
 msgid "Normal Mode"
-msgstr "Mode Normal"
+msgstr "Modo normal"
 
-#: common.py:79
+#: common.py:96 common.py:123
 msgid "Performance Mode"
-msgstr "Modo de Alto Rendimiento"
+msgstr "Modo de alto rendimiento"
 
-#: common.py:80
+#: common.py:97 common.py:124
 msgid "Dynamic Mode"
-msgstr "Mode Dinámico"
+msgstr "Modo dinámico"
 
-#: common.py:82
+#: common.py:99 common.py:126
 msgid "Touchpad enabled"
-msgstr "Touchpad activado"
+msgstr "Panel táctil activado"
 
-#: common.py:83
+#: common.py:100 common.py:127
 msgid "Touchpad disabled"
-msgstr "Touchpad desactivado"
+msgstr "Panel táctil desactivado"
 
-#: common.py:84
+#: common.py:101 common.py:128
 msgid "Touchpad changed"
-msgstr "El Touchpad ha cambiado"
+msgstr "El panel táctil ha cambiado"
 
-#: common.py:85
+#: common.py:102 common.py:129
 msgid "Webcam changed"
 msgstr "La cámara web ha cambiado"
 
-#: common.py:86
+#: common.py:103 common.py:130
 msgid "Webcam enabled"
 msgstr "Cámara web activada"
 
-#: common.py:87
+#: common.py:104 common.py:131
 msgid "Webcam disabled"
 msgstr "Cámara web desactivada"
 
-#: common.py:89
+#: common.py:106 common.py:133
 msgid "Energy Saver"
 msgstr "Ahorro de energía"
 
-#: common.py:90
+#: common.py:107 common.py:134
 msgid "Balanced"
 msgstr "Equilibrado"
 
-#: common.py:91
+#: common.py:108 common.py:135
 msgid "Performance"
 msgstr "Rendimiento"
 
-#: common.py:167
+#: common.py:257
 msgid "Uptime"
 msgstr "Tiempo en funcionamiento"
 
-#: common.py:168
+#: common.py:258
 msgid "Memory Free/Total"
 msgstr "Memoria libre/total"
 
-#: common.py:169
+#: common.py:259
 msgid "Memory device"
 msgstr "Dispositivo de memoria"
 
-#: common.py:170
+#: common.py:260
 msgid "UMA"
 msgstr "UMA"
 
-#: common.py:171
+#: common.py:261
 msgid "Disk Free/Total"
 msgstr "Espacio en disco libre/total"
 
-#: common.py:172
+#: common.py:262
 msgid "Kernel"
 msgstr "Núcleo"
 
-#: common.py:173
+#: common.py:263
 msgid "OS"
 msgstr "Sistema operativo"
 
-#: common.py:174
+#: common.py:264
 msgid "Desktop"
 msgstr "Escritorio"
 
-#: common.py:175
+#: common.py:265
 msgid "Session"
 msgstr "Sesión"
 
-#: common.py:176
+#: common.py:266
 msgid "Product"
 msgstr "Producto"
 
-#: common.py:177
+#: common.py:267
 msgid "Serial"
 msgstr "Número de serie"
 
-#: common.py:178
+#: common.py:268
 msgid "Bios Version"
 msgstr "Versión de la Bios"
 
-#: common.py:179
+#: common.py:269
 msgid "EC Version"
 msgstr "Versión del EC"
 
-#: common.py:180
+#: common.py:270
 msgid "Boot Mode"
 msgstr "Modo de arranque"
 
-#: common.py:181
+#: common.py:271
 msgid "Secure Boot"
 msgstr "Arranque seguro"
 
-#: common.py:182
+#: common.py:272
 msgid "CPU"
 msgstr "CPU"
 
-#: common.py:183
+#: common.py:273
 msgid "TDP"
 msgstr "TDP"
 
-#: common.py:184
+#: common.py:274
 msgid "GPU"
 msgstr "GPU"
 
-#: common.py:185
+#: common.py:275
 msgid "Module loaded"
 msgstr "Módulo cargado"
 
-#: common.py:186
+#: common.py:276
 msgid "Fn Lock"
 msgstr "Bloqueo tecla «Fn»"
 
-#: common.py:187
+#: common.py:277
 msgid "Super Lock"
 msgstr "Bloqueo tecla «Super»"
 
-#: common.py:189
+#: common.py:279
 msgid "Turbo Mode"
-msgstr "Modo Turbo"
+msgstr "Modo turbo"
 
-#: common.py:190
+#: common.py:280
 msgid "Profile"
 msgstr "Perfil"
 
-#: common.py:192
+#: common.py:282
 msgid "Yes"
 msgstr "Si"
 
-#: common.py:193
+#: common.py:283
 msgid "No"
 msgstr "No"
+
+#~ msgid "Slimbok Client Notifications"
+#~ msgstr "Notificaciones del cliente Slimbook"
+
+#~ msgid "Visit Website"
+#~ msgstr "Visita la página web"
+
+#~ msgid "Report issue"
+#~ msgstr "Informar de un problema"
+
+#~ msgid ""
+#~ "This is a report of several hardware and software stats.\n"
+#~ "Full report generates a report with sensitive information,\n"
+#~ "beware of sharing it online!"
+#~ msgstr ""
+#~ "Esto es un informe que contiene información y estadísticas del equipo.\n"
+#~ "El informe completo genera un informe con datos sensibles,\n"
+#~ "id con cuidado a la hora de compartirlo en linea"
+
+#~ msgid "Open"
+#~ msgstr "Abrir"
+
+#~ msgid "Succesful! Dumped at "
+#~ msgstr "¡Éxito! Se ha generado:"
+
+#~ msgid ""
+#~ "Error! Report wasn't able to be generated\n"
+#~ "Error: "
+#~ msgstr ""
+#~ "Se ha producido un error y el informe no se ha generado\n"
+#~ "Error: "

--- a/slimbook/usr/share/slimbook/locale-langpack/slimbook.pot
+++ b/slimbook/usr/share/slimbook/locale-langpack/slimbook.pot
@@ -8,320 +8,334 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-18 15:11+0200\n"
+"POT-Creation-Date: 2026-06-28 16:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: client.py:76
-msgid "Slimbok Client Notifications"
-msgstr ""
-
-#: client.py:426
+#: client.py:386
 msgid "Notifications"
 msgstr ""
 
-#: client.py:431
-msgid "System information"
+#: client.py:391
+msgid "System Information"
 msgstr ""
 
-#: client.py:436
+#: client.py:395
 msgid "Preferences"
 msgstr ""
 
-#: client.py:445
+#: client.py:403
+msgid "Control Panel"
+msgstr ""
+
+#: client.py:411
 msgid "About"
 msgstr ""
 
-#: client.py:450 client.py:590
-msgid "Generate report"
+#: client.py:415 client.py:554 client.py:566
+msgid "Generate Report"
 msgstr ""
 
-#: client.py:456
-msgid "Report a bug..."
+#: client.py:420
+msgid "Report a Bug…"
 msgstr ""
 
-#: client.py:467
+#: client.py:430
 msgid "Exit"
 msgstr ""
 
-#: client.py:483 common.py:129
+#: client.py:494 common.py:218
 msgid "Slimbook Service"
 msgstr ""
 
-#: client.py:496
-msgid "Visit Website"
+#: client.py:500
+msgid "translator-credits"
 msgstr ""
 
-#: client.py:498
-msgid "Report issue"
-msgstr ""
-
-#: client.py:505
-msgid "translation-credits"
-msgstr ""
-
-#: client.py:612
+#: client.py:568
 msgid ""
-"This is a report of several hardware and software stats.\n"
-"Full report generates a report with sensitive information,\n"
-"beware of sharing it online!"
+"Creates a compressed archive with hardware and software information. The "
+"full report also includes sensitive data such as MAC address and board "
+"serial number"
 msgstr ""
 
-#: client.py:622
+#: client.py:572
 msgid "Report"
 msgstr ""
 
-#: client.py:625
-msgid "Full report"
+#: client.py:575
+msgid "Full Report"
 msgstr ""
 
-#: client.py:649
-msgid "Open"
+#: client.py:584
+msgid "Generating…"
 msgstr ""
 
-#: client.py:652 client.py:679
+#: client.py:591
+msgid "Open Folder"
+msgstr ""
+
+#: client.py:600
 msgid "Close"
 msgstr ""
 
-#: client.py:698
-msgid "Succesful! Dumped at "
+#: client.py:620
+msgid "Error"
 msgstr ""
 
-#: client.py:706
-msgid ""
-"Error! Report wasn't able to be generated\n"
-"Error: "
+#: client.py:622
+msgid "The report could not be generated:\n"
 msgstr ""
 
-#: client.py:762
+#: client.py:627
+msgid "Report Generated"
+msgstr ""
+
+#: client.py:628
+msgid "Saved at "
+msgstr ""
+
+#: client.py:677
+msgid "Show Indicator"
+msgstr ""
+
+#: client.py:678
+msgid "Autostart"
+msgstr ""
+
+#: client.py:679
+msgid "Light-Mode Icon"
+msgstr ""
+
+#: client.py:680
+msgid "Check Notifications"
+msgstr ""
+
+#: client.py:681
+msgid "Trackpad Lock"
+msgstr ""
+
+#: client.py:682
+msgid "Set Power Profile"
+msgstr ""
+
+#: client.py:683
+msgid "AC Notifications"
+msgstr ""
+
+#: client.py:688
 msgid "Slimbook Preferences"
 msgstr ""
 
-#: client.py:765
+#: client.py:703
 msgid "Save"
 msgstr ""
 
 #: client.py:777
-msgid "Show indicator"
+msgid "Slimbook System Information"
 msgstr ""
 
-#: client.py:784
-msgid "Autostart"
+#: client.py:783
+msgid "Copy to Clipboard"
 msgstr ""
 
-#: client.py:791
-msgid "Light-mode Icon"
+#: client.py:820
+msgid "Copied to clipboard"
 msgstr ""
 
-#: client.py:798
-msgid "Check Notifications"
-msgstr ""
-
-#: client.py:805
-msgid "Trackpad lock"
-msgstr ""
-
-#: client.py:812
-msgid "Set power profile"
-msgstr ""
-
-#: client.py:887
-msgid "Slimbook System information"
-msgstr ""
-
-#: client.py:1003
+#: client.py:832
 msgid "Slimbook Notifications"
 msgstr ""
 
-#: client.py:1006
+#: client.py:839
 msgid "Refresh"
 msgstr ""
 
-#: client.py:1069
-msgid "Nothing to show"
+#: client.py:896
+msgid "Nothing to Show"
 msgstr ""
 
-#: client.py:1105
-msgid "Fetching..."
+#: client.py:910
+msgid "Fetching…"
 msgstr ""
 
-#: common.py:69
+#: common.py:86 common.py:113
 msgid "Silent Mode enabled"
 msgstr ""
 
-#: common.py:70
+#: common.py:87 common.py:114
 msgid "Silent Mode disabled"
 msgstr ""
 
-#: common.py:71
+#: common.py:88 common.py:115
 msgid "Silent Mode changed"
 msgstr ""
 
-#: common.py:73
+#: common.py:90 common.py:117
 msgid "Super Key Lock enabled"
 msgstr ""
 
-#: common.py:74
+#: common.py:91 common.py:118
 msgid "Super Key Lock disabled"
 msgstr ""
 
-#: common.py:75
+#: common.py:92 common.py:119
 msgid "Super Key Lock changed"
 msgstr ""
 
-#: common.py:77 common.py:188
+#: common.py:94 common.py:121 common.py:278
 msgid "Silent Mode"
 msgstr ""
 
-#: common.py:78
+#: common.py:95 common.py:122
 msgid "Normal Mode"
 msgstr ""
 
-#: common.py:79
+#: common.py:96 common.py:123
 msgid "Performance Mode"
 msgstr ""
 
-#: common.py:80
+#: common.py:97 common.py:124
 msgid "Dynamic Mode"
 msgstr ""
 
-#: common.py:82
+#: common.py:99 common.py:126
 msgid "Touchpad enabled"
 msgstr ""
 
-#: common.py:83
+#: common.py:100 common.py:127
 msgid "Touchpad disabled"
 msgstr ""
 
-#: common.py:84
+#: common.py:101 common.py:128
 msgid "Touchpad changed"
 msgstr ""
 
-#: common.py:85
+#: common.py:102 common.py:129
 msgid "Webcam changed"
 msgstr ""
 
-#: common.py:86
+#: common.py:103 common.py:130
 msgid "Webcam enabled"
 msgstr ""
 
-#: common.py:87
+#: common.py:104 common.py:131
 msgid "Webcam disabled"
 msgstr ""
 
-#: common.py:89
+#: common.py:106 common.py:133
 msgid "Energy Saver"
 msgstr ""
 
-#: common.py:90
+#: common.py:107 common.py:134
 msgid "Balanced"
 msgstr ""
 
-#: common.py:91
+#: common.py:108 common.py:135
 msgid "Performance"
 msgstr ""
 
-#: common.py:167
+#: common.py:257
 msgid "Uptime"
 msgstr ""
 
-#: common.py:168
+#: common.py:258
 msgid "Memory Free/Total"
 msgstr ""
 
-#: common.py:169
+#: common.py:259
 msgid "Memory device"
 msgstr ""
 
-#: common.py:170
+#: common.py:260
 msgid "UMA"
 msgstr ""
 
-#: common.py:171
+#: common.py:261
 msgid "Disk Free/Total"
 msgstr ""
 
-#: common.py:172
+#: common.py:262
 msgid "Kernel"
 msgstr ""
 
-#: common.py:173
+#: common.py:263
 msgid "OS"
 msgstr ""
 
-#: common.py:174
+#: common.py:264
 msgid "Desktop"
 msgstr ""
 
-#: common.py:175
+#: common.py:265
 msgid "Session"
 msgstr ""
 
-#: common.py:176
+#: common.py:266
 msgid "Product"
 msgstr ""
 
-#: common.py:177
+#: common.py:267
 msgid "Serial"
 msgstr ""
 
-#: common.py:178
+#: common.py:268
 msgid "Bios Version"
 msgstr ""
 
-#: common.py:179
+#: common.py:269
 msgid "EC Version"
 msgstr ""
 
-#: common.py:180
+#: common.py:270
 msgid "Boot Mode"
 msgstr ""
 
-#: common.py:181
+#: common.py:271
 msgid "Secure Boot"
 msgstr ""
 
-#: common.py:182
+#: common.py:272
 msgid "CPU"
 msgstr ""
 
-#: common.py:183
+#: common.py:273
 msgid "TDP"
 msgstr ""
 
-#: common.py:184
+#: common.py:274
 msgid "GPU"
 msgstr ""
 
-#: common.py:185
+#: common.py:275
 msgid "Module loaded"
 msgstr ""
 
-#: common.py:186
+#: common.py:276
 msgid "Fn Lock"
 msgstr ""
 
-#: common.py:187
+#: common.py:277
 msgid "Super Lock"
 msgstr ""
 
-#: common.py:189
+#: common.py:279
 msgid "Turbo Mode"
 msgstr ""
 
-#: common.py:190
+#: common.py:280
 msgid "Profile"
 msgstr ""
 
-#: common.py:192
+#: common.py:282
 msgid "Yes"
 msgstr ""
 
-#: common.py:193
+#: common.py:283
 msgid "No"
 msgstr ""

--- a/slimbook/usr/share/slimbook/slimbook-indicator.desktop
+++ b/slimbook/usr/share/slimbook/slimbook-indicator.desktop
@@ -9,5 +9,5 @@ NoDisplay=false
 StartupNotify=false
 Encoding=UTF-8
 Name[ca_ES]=Servei Slimbook
-Name[es_ES]=Slimbook Service
+Name[es]=Servicio Slimbook
 Name=Slimbook Service

--- a/slimbook/usr/share/slimbook/sni.py
+++ b/slimbook/usr/share/slimbook/sni.py
@@ -1,0 +1,325 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# Slimbook Service
+# Copyright (C) 2026 Slimbook
+# In case you modify or redistribute this code you must keep the copyright line above.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# StatusNotifierItem + com.canonical.dbusmenu implementation via python-dbus.
+# Replaces AyatanaAppIndicator3 so the indicator can run as a pure GTK4 process.
+
+import logging
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+
+# Integrate D-Bus GLib main loop with the GLib main loop already used by the app.
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+# ---------------------------------------------------------------------------
+# Status constants (mirror AppIndicator's IndicatorStatus enum)
+# ---------------------------------------------------------------------------
+STATUS_ACTIVE = "Active"
+STATUS_PASSIVE = "Passive"
+STATUS_NEEDS_ATTENTION = "NeedsAttention"
+
+CATEGORY_HARDWARE = "Hardware"
+
+
+# ---------------------------------------------------------------------------
+# DBusMenu  (com.canonical.dbusmenu)
+# ---------------------------------------------------------------------------
+_DBUSMENU_IFACE = "com.canonical.dbusmenu"
+
+
+class _DbusMenu(dbus.service.Object):
+    """Minimal DBusMenu implementation.
+
+    Items are plain dicts::
+
+        {"label": str, "callback": callable|None,
+         "sensitive": bool, "type": "standard"|"separator",
+         "id": int}   # assigned internally
+    """
+
+    def __init__(self, bus, path):
+        dbus.service.Object.__init__(self, bus, path)
+        self._items = []
+        self._revision = 0
+
+    def set_items(self, items):
+        """Replace menu contents. items: list of dicts (label/callback/sensitive/type)."""
+        self._items = []
+        for idx, item in enumerate(items):
+            entry = dict(item)
+            entry["id"] = idx + 1          # id=0 is reserved for root
+            entry.setdefault("sensitive", True)
+            entry.setdefault("type", "standard")
+            entry.setdefault("callback", None)
+            self._items.append(entry)
+        self._revision += 1
+        self.LayoutUpdated(self._revision, 0)
+
+    def _item_props(self, item):
+        props = dbus.Dictionary(signature="sv")
+        props["label"] = dbus.String(item.get("label", ""))
+        props["enabled"] = dbus.Boolean(item.get("sensitive", True))
+        props["visible"] = dbus.Boolean(True)
+        props["type"] = dbus.String(item.get("type", "standard"))
+        return props
+
+    def _build_layout(self, parent_id, recursion_depth, property_names):
+        """Return (id, props, children) tuple for the root."""
+        root_props = dbus.Dictionary(signature="sv")
+        children = dbus.Array(signature="v")
+        for item in self._items:
+            child_props = self._item_props(item)
+            child = dbus.Struct(
+                [dbus.Int32(item["id"]), child_props, dbus.Array([], signature="v")],
+                signature=None,
+            )
+            children.append(dbus.Struct(child, signature=None))
+        return dbus.Struct(
+            [dbus.Int32(0), root_props, children],
+            signature=None,
+        )
+
+    # --- DBus methods ---
+
+    @dbus.service.method(_DBUSMENU_IFACE,
+                         in_signature="iias", out_signature="u(ia{sv}av)")
+    def GetLayout(self, parent_id, recursion_depth, property_names):
+        layout = self._build_layout(parent_id, recursion_depth, property_names)
+        return dbus.UInt32(self._revision), layout
+
+    @dbus.service.method(_DBUSMENU_IFACE,
+                         in_signature="aias", out_signature="a(ia{sv})")
+    def GetGroupProperties(self, ids, property_names):
+        result = []
+        for item in self._items:
+            if item["id"] in ids:
+                result.append((dbus.Int32(item["id"]), self._item_props(item)))
+        return result
+
+    @dbus.service.method(_DBUSMENU_IFACE,
+                         in_signature="isvu", out_signature="")
+    def Event(self, id, event_id, data, timestamp):
+        if event_id == "clicked":
+            for item in self._items:
+                if item["id"] == id and item.get("callback"):
+                    try:
+                        item["callback"]()
+                    except Exception as e:
+                        logging.error("DBusMenu callback error: %s", e)
+
+    @dbus.service.method(_DBUSMENU_IFACE,
+                         in_signature="i", out_signature="b")
+    def AboutToShow(self, id):
+        return False
+
+    @dbus.service.method(_DBUSMENU_IFACE,
+                         in_signature="ai", out_signature="aiai")
+    def AboutToShowGroup(self, ids):
+        return [], []
+
+    @dbus.service.method(_DBUSMENU_IFACE,
+                         in_signature="a(isvu)", out_signature="")
+    def EventGroup(self, events):
+        for id, event_id, data, timestamp in events:
+            self.Event(id, event_id, data, timestamp)
+
+    # --- DBus signals ---
+
+    @dbus.service.signal(_DBUSMENU_IFACE, signature="ui")
+    def LayoutUpdated(self, revision, parent):
+        pass
+
+    @dbus.service.signal(_DBUSMENU_IFACE, signature="a(ia{sv})")
+    def ItemsPropertiesUpdated(self, updated_props):
+        pass
+
+    # --- DBus properties ---
+
+    @dbus.service.method(dbus.PROPERTIES_IFACE,
+                         in_signature="ss", out_signature="v")
+    def Get(self, iface, prop):
+        return self.GetAll(iface)[prop]
+
+    @dbus.service.method(dbus.PROPERTIES_IFACE,
+                         in_signature="s", out_signature="a{sv}")
+    def GetAll(self, iface):
+        return {
+            "Version": dbus.UInt32(3),
+            "TextDirection": dbus.String("ltr"),
+            "Status": dbus.String("normal"),
+            "IconThemePath": dbus.Array([], signature="s"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# StatusNotifierItem  (org.kde.StatusNotifierItem)
+# ---------------------------------------------------------------------------
+_SNI_IFACE = "org.kde.StatusNotifierItem"
+_SNW_NAME = "org.kde.StatusNotifierWatcher"
+_SNW_PATH = "/StatusNotifierWatcher"
+
+
+class StatusNotifierItem(dbus.service.Object):
+    """GTK4-compatible system tray icon via the StatusNotifierItem D-Bus protocol.
+
+    Usage::
+
+        item = StatusNotifierItem("com.slimbook.service", icon_name, "Hardware")
+        item.set_title("Slimbook")
+        item.set_attention_icon("slimbook-status-attention-dark")
+        item.set_menu([
+            {"label": "Preferences", "callback": show_prefs},
+            {"label": "", "type": "separator"},
+            {"label": "Exit", "callback": do_exit},
+        ])
+        item.set_status(STATUS_ACTIVE)
+    """
+
+    def __init__(self, app_id, icon_name, category=CATEGORY_HARDWARE):
+        self._bus = dbus.SessionBus()
+        # Request a unique bus name so the watcher can identify us
+        self._bus_name = dbus.service.BusName(
+            "org.kde.StatusNotifierItem-{0}-1".format(app_id.replace(".", "-")),
+            self._bus,
+        )
+        dbus.service.Object.__init__(self, self._bus, "/StatusNotifierItem")
+
+        self._id = app_id
+        self._category = category
+        self._title = app_id
+        self._status = STATUS_ACTIVE
+        self._icon_name = icon_name or ""
+        self._attention_icon_name = ""
+        self._menu_path = dbus.ObjectPath("/MenuBar")
+
+        self._menu = _DbusMenu(self._bus, "/MenuBar")
+
+        self._register()
+
+        # Re-register if the watcher restarts
+        self._bus.add_signal_receiver(
+            self._on_name_owner_changed,
+            signal_name="NameOwnerChanged",
+            dbus_interface="org.freedesktop.DBus",
+            arg0=_SNW_NAME,
+        )
+
+    def _register(self):
+        try:
+            watcher = self._bus.get_object(_SNW_NAME, _SNW_PATH)
+            watcher.RegisterStatusNotifierItem(
+                self._bus_name.get_name(),
+                dbus_interface=_SNW_NAME,
+            )
+            logging.debug("SNI registered with watcher")
+        except dbus.DBusException as e:
+            logging.warning("SNI watcher not available: %s", e)
+
+    def _on_name_owner_changed(self, name, old_owner, new_owner):
+        if new_owner:
+            logging.debug("SNI watcher reappeared, re-registering")
+            self._register()
+
+    # --- Public API ---
+
+    def set_title(self, title):
+        self._title = title
+        self.NewTitle()
+
+    def set_icon(self, icon_name):
+        self._icon_name = icon_name
+        self.NewIcon()
+
+    def set_attention_icon(self, icon_name):
+        self._attention_icon_name = icon_name
+        self.NewAttentionIcon()
+
+    def set_status(self, status):
+        self._status = status
+        self.NewStatus(status)
+
+    def set_menu(self, items):
+        """items: list of dicts with keys label, callback, sensitive, type."""
+        self._menu.set_items(items)
+
+    # --- D-Bus methods ---
+
+    @dbus.service.method(_SNI_IFACE, in_signature="", out_signature="")
+    def Activate(self, *args):
+        pass
+
+    @dbus.service.method(_SNI_IFACE, in_signature="", out_signature="")
+    def SecondaryActivate(self, *args):
+        pass
+
+    @dbus.service.method(_SNI_IFACE, in_signature="i", out_signature="")
+    def Scroll(self, delta, *args):
+        pass
+
+    # --- D-Bus signals ---
+
+    @dbus.service.signal(_SNI_IFACE)
+    def NewTitle(self):
+        pass
+
+    @dbus.service.signal(_SNI_IFACE)
+    def NewIcon(self):
+        pass
+
+    @dbus.service.signal(_SNI_IFACE)
+    def NewAttentionIcon(self):
+        pass
+
+    @dbus.service.signal(_SNI_IFACE, signature="s")
+    def NewStatus(self, status):
+        pass
+
+    @dbus.service.signal(_SNI_IFACE)
+    def NewIconThemePath(self):
+        pass
+
+    # --- D-Bus properties ---
+
+    @dbus.service.method(dbus.PROPERTIES_IFACE,
+                         in_signature="ss", out_signature="v")
+    def Get(self, iface, prop):
+        return self.GetAll(iface)[prop]
+
+    @dbus.service.method(dbus.PROPERTIES_IFACE,
+                         in_signature="s", out_signature="a{sv}")
+    def GetAll(self, iface):
+        return {
+            "Category":          dbus.String(self._category),
+            "Id":                dbus.String(self._id),
+            "Title":             dbus.String(self._title),
+            "Status":            dbus.String(self._status),
+            "IconName":          dbus.String(self._icon_name),
+            "IconPixmap":        dbus.Array([], signature="(iiay)"),
+            "AttentionIconName": dbus.String(self._attention_icon_name),
+            "AttentionIconPixmap": dbus.Array([], signature="(iiay)"),
+            "OverlayIconName":   dbus.String(""),
+            "ToolTip":           dbus.Struct(
+                ["", dbus.Array([], signature="(iiay)"), self._title, ""],
+                signature=None,
+            ),
+            "Menu":              dbus.ObjectPath(self._menu_path),
+            "ItemIsMenu":        dbus.Boolean(False),
+        }


### PR DESCRIPTION
AyatanaAppIndicator3 has no GTK4 port and none is planned. Python libraries that abstract system trays (e.g. pystray) use AppIndicator3 as their Linux backend and carry the same GTK3 dependency, so a custom [StatusNotifierItem](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/) implementation over `python-dbus` (`sni.py`) is the only viable path for a pure GTK4 process.

All five dialogs have been migrated to GTK4 + Libadwaita following GNOME HIG guidelines: `PreferencesDialog`, `AboutDialog`, `SystemInfoDialog`, `NotificationsDialog`, `ReportDialog`.

## Dependency changes

| Removed | Added |
|---|---|
| `gir1.2-ayatanaappindicator3-0.1` | `gir1.2-gtk-4.0` |
| `gir1.2-gtk-3.0` | `gir1.2-adw-1` |
| | `python3-dbus` |