### PR TITLE
Allow alternative keyboard devices for notifications

### DIFF
--- a/slimbook/usr/share/slimbook/event-notify.py
+++ b/slimbook/usr/share/slimbook/event-notify.py
@@ -65,23 +65,6 @@ settings = {
     common.OPT_AC_NOTIFICATIONS: True
 }
 
-_OSD_PROFILE_MAP = {
-    common.SLB_EVENT_ENERGY_SAVER_MODE: "power-saver",
-    common.SLB_EVENT_BALANCED_MODE: "balanced",
-    common.SLB_EVENT_PERFORMANCE_MODE: "performance",
-}
-
-def _get_active_user_uid():
-    try:
-        uid = subprocess.check_output(
-            "loginctl list-sessions --no-legend | head -1 | awk '{print $2}'",
-            shell=True, text=True).strip()
-        if uid and uid.isdigit():
-            return int(uid)
-    except:
-        pass
-    return None
-
 def set_power_profile(profile):
     #ToDo: refactor this using Dbus instead
     if (settings[common.OPT_POWER_PROFILE]):
@@ -184,48 +167,34 @@ def zmq_worker():
         
         socket_ctl.send_json({})
     
-def _find_keyd_device():
+def _find_alt_keyboard():
     try:
-        for path in evdev.list_devices():
-            device = evdev.InputDevice(path)
-            if device.name == "keyd virtual keyboard":
-                device.close()
-                return path
-            device.close()
+        default = os.path.realpath(slimbook.info.keyboard_device())
     except:
-        pass
+        default = os.path.realpath("/dev/input/by-path/platform-i8042-serio-0-event-kbd")
+    for path in evdev.list_devices():
+        if os.path.realpath(path) == default:
+            continue
+        try:
+            device = evdev.InputDevice(path)
+            caps = device.capabilities()
+            device.close()
+            if evdev.ecodes.EV_KEY not in caps:
+                continue
+            if evdev.ecodes.EV_REL in caps or evdev.ecodes.EV_ABS in caps:
+                continue
+            if evdev.ecodes.KEY_F16 in caps[evdev.ecodes.EV_KEY]:
+                return path
+        except:
+            pass
     return None
-
-_KEYD_HWDB_PATH = "/etc/udev/hwdb.d/99-slimbook-hotkeys.hwdb"
-_KEYD_HWDB_CONTENT = (
-    "evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:pn*:pvr*\n"
-    " KEYBOARD_KEY_f2=f16\n"
-    " KEYBOARD_KEY_f9=f17\n"
-    " KEYBOARD_KEY_e2=f18\n"
-)
-
-def _setup_keyd_hwdb():
-    try:
-        current = ""
-        if os.path.exists(_KEYD_HWDB_PATH):
-            with open(_KEYD_HWDB_PATH, "r") as f:
-                current = f.read()
-        if current != _KEYD_HWDB_CONTENT:
-            logger.info("installing keyd hwdb rules")
-            with open(_KEYD_HWDB_PATH, "w") as f:
-                f.write(_KEYD_HWDB_CONTENT)
-            subprocess.run(["systemd-hwdb", "update"])
-            subprocess.run(["udevadm", "trigger", "--sysname-match=event*"])
-            logger.info("hwdb updated, udev triggered")
-    except Exception as e:
-        logger.warning("failed to setup keyd hwdb: {0}".format(e))
 
 def keyboard_worker():
     
-    device_path = _find_keyd_device()
-    uses_keyd = device_path is not None
-    if uses_keyd:
-        logger.info("using keyd virtual keyboard: {0}".format(device_path))
+    device_path = _find_alt_keyboard()
+    uses_alt = device_path is not None
+    if uses_alt:
+        logger.info("using alt keyboard device: {0}".format(device_path))
     else:
         device_path = "/dev/input/by-path/platform-i8042-serio-0-event-kbd"
         # work around for buggy dmi info
@@ -239,7 +208,7 @@ def keyboard_worker():
     state = {}
     
     for event in device.read_loop():
-        if uses_keyd:
+        if uses_alt:
             if event.type == evdev.ecodes.EV_KEY and event.value == 1:
                 if event.code == evdev.ecodes.KEY_F16:
                     slb_events.put(common.SLB_EVENT_ENERGY_SAVER_MODE)
@@ -299,21 +268,6 @@ def send_notify(code):
     dt = datetime.now()
     ts = datetime.timestamp(dt)
     data = {"code": code, "timestamp": ts}
-
-    profile_name = _OSD_PROFILE_MAP.get(code)
-    if profile_name:
-        uid = _get_active_user_uid()
-        if uid is not None:
-            try:
-                subprocess.run(
-                    "sudo -u '#{0}' env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{0}/bus "
-                    "busctl --user call org.kde.plasmashell /org/kde/osdService "
-                    "org.kde.osdService powerProfileChanged s {1}".format(uid, profile_name),
-                    shell=True)
-                return
-            except:
-                pass
-
     socket_out.send_json(data)
     
 def main():
@@ -364,9 +318,6 @@ def main():
     
     module_loaded = slimbook.info.is_module_loaded()
     
-    if _find_keyd_device():
-        _setup_keyd_hwdb()
-
     if (platform == slimbook.info.SLB_PLATFORM_QC71):
         qc71_keyboard_thread = threading.Thread(
             name='slimbook.service.qc71.keyboard', target=keyboard_worker)

--- a/slimbook/usr/share/slimbook/event-notify.py
+++ b/slimbook/usr/share/slimbook/event-notify.py
@@ -65,6 +65,23 @@ settings = {
     common.OPT_AC_NOTIFICATIONS: True
 }
 
+_OSD_PROFILE_MAP = {
+    common.SLB_EVENT_ENERGY_SAVER_MODE: "power-saver",
+    common.SLB_EVENT_BALANCED_MODE: "balanced",
+    common.SLB_EVENT_PERFORMANCE_MODE: "performance",
+}
+
+def _get_active_user_uid():
+    try:
+        uid = subprocess.check_output(
+            "loginctl list-sessions --no-legend | head -1 | awk '{print $2}'",
+            shell=True, text=True).strip()
+        if uid and uid.isdigit():
+            return int(uid)
+    except:
+        pass
+    return None
+
 def set_power_profile(profile):
     #ToDo: refactor this using Dbus instead
     if (settings[common.OPT_POWER_PROFILE]):
@@ -167,20 +184,71 @@ def zmq_worker():
         
         socket_ctl.send_json({})
     
-def keyboard_worker():
-    
-    device_path = "/dev/input/by-path/platform-i8042-serio-0-event-kbd"
-    # work around for buggy dmi info
+def _find_keyd_device():
     try:
-        device_path = slimbook.info.keyboard_device()
+        for path in evdev.list_devices():
+            device = evdev.InputDevice(path)
+            if device.name == "keyd virtual keyboard":
+                device.close()
+                return path
+            device.close()
     except:
         pass
+    return None
+
+_KEYD_HWDB_PATH = "/etc/udev/hwdb.d/99-slimbook-hotkeys.hwdb"
+_KEYD_HWDB_CONTENT = (
+    "evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:pn*:pvr*\n"
+    " KEYBOARD_KEY_f2=f16\n"
+    " KEYBOARD_KEY_f9=f17\n"
+    " KEYBOARD_KEY_e2=f18\n"
+)
+
+def _setup_keyd_hwdb():
+    try:
+        current = ""
+        if os.path.exists(_KEYD_HWDB_PATH):
+            with open(_KEYD_HWDB_PATH, "r") as f:
+                current = f.read()
+        if current != _KEYD_HWDB_CONTENT:
+            logger.info("installing keyd hwdb rules")
+            with open(_KEYD_HWDB_PATH, "w") as f:
+                f.write(_KEYD_HWDB_CONTENT)
+            subprocess.run(["systemd-hwdb", "update"])
+            subprocess.run(["udevadm", "trigger", "--sysname-match=event*"])
+            logger.info("hwdb updated, udev triggered")
+    except Exception as e:
+        logger.warning("failed to setup keyd hwdb: {0}".format(e))
+
+def keyboard_worker():
+    
+    device_path = _find_keyd_device()
+    uses_keyd = device_path is not None
+    if uses_keyd:
+        logger.info("using keyd virtual keyboard: {0}".format(device_path))
+    else:
+        device_path = "/dev/input/by-path/platform-i8042-serio-0-event-kbd"
+        # work around for buggy dmi info
+        try:
+            device_path = slimbook.info.keyboard_device()
+        except:
+            pass
         
     device = evdev.InputDevice(device_path)
     
     state = {}
     
     for event in device.read_loop():
+        if uses_keyd:
+            if event.type == evdev.ecodes.EV_KEY and event.value == 1:
+                if event.code == evdev.ecodes.KEY_F16:
+                    slb_events.put(common.SLB_EVENT_ENERGY_SAVER_MODE)
+                elif event.code == evdev.ecodes.KEY_F17:
+                    slb_events.put(common.SLB_EVENT_BALANCED_MODE)
+                elif event.code == evdev.ecodes.KEY_F18:
+                    slb_events.put(common.SLB_EVENT_PERFORMANCE_MODE)
+            continue
+
         if (event.type == evdev.ecodes.EV_MSC):
         
             last = state.get(event.value)
@@ -231,6 +299,21 @@ def send_notify(code):
     dt = datetime.now()
     ts = datetime.timestamp(dt)
     data = {"code": code, "timestamp": ts}
+
+    profile_name = _OSD_PROFILE_MAP.get(code)
+    if profile_name:
+        uid = _get_active_user_uid()
+        if uid is not None:
+            try:
+                subprocess.run(
+                    "sudo -u '#{0}' env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{0}/bus "
+                    "busctl --user call org.kde.plasmashell /org/kde/osdService "
+                    "org.kde.osdService powerProfileChanged s {1}".format(uid, profile_name),
+                    shell=True)
+                return
+            except:
+                pass
+
     socket_out.send_json(data)
     
 def main():
@@ -281,6 +364,8 @@ def main():
     
     module_loaded = slimbook.info.is_module_loaded()
     
+    _setup_keyd_hwdb()
+
     if (platform == slimbook.info.SLB_PLATFORM_QC71):
         qc71_keyboard_thread = threading.Thread(
             name='slimbook.service.qc71.keyboard', target=keyboard_worker)

--- a/slimbook/usr/share/slimbook/event-notify.py
+++ b/slimbook/usr/share/slimbook/event-notify.py
@@ -364,7 +364,8 @@ def main():
     
     module_loaded = slimbook.info.is_module_loaded()
     
-    _setup_keyd_hwdb()
+    if _find_keyd_device():
+        _setup_keyd_hwdb()
 
     if (platform == slimbook.info.SLB_PLATFORM_QC71):
         qc71_keyboard_thread = threading.Thread(


### PR DESCRIPTION
## keyd + KDE Plasma: Fn+F10-F12 hotkey support and native OSD notifications

### Problem

On a KDE Plasma laptop (EXCALIBUR-16-AMD7), there are no dedicated PgUp/PgDn/Home/End keys and no Enter on the numpad. Using **keyd**, I remapped the `<>` key (next to left Shift) as a modifier: `<>+1/7/9/3` = End/Home/PgUp/PgDn, `<>+.` on numpad = Enter.

However, with keyd running, the **Fn+F10-F12 keys stopped working** — slimbook_service could no longer switch power profiles.

Root cause: keyd grabs the evdev keyboard device, so raw PS/2 scan codes (`platform-i8042-serio-0-event-kbd`) no longer reach slimbook_service. Instead, keyd creates a virtual device (`keyd virtual keyboard`) that emits processed key events — but the Fn+F10-F12 scan codes are not mapped by default and get lost.

### Solution

1. **hwdb rules (keyd only)** — if keyd is detected, `/etc/udev/hwdb.d/99-slimbook-hotkeys.hwdb` is created, mapping scan codes `f2/f9/e2` (Fn+F10/F11/F12) to F16/F17/F18 keys
2. **keyd detection** — `keyboard_worker()` checks for `keyd virtual keyboard` among evdev devices. If found, reads EV_KEY (F16-F18) instead of raw scan codes. If keyd is absent, falls back to the original PS/2 logic
3. **Native KDE Plasma 6 OSD** — power profile change notifications via `busctl` + `org.kde.osdService`. On KDE, the native OSD replaces the regular notification (no duplicates). Other DEs are unaffected
4. **Original logic untouched** — `set_power_profile()` and all other code unchanged

### Changed file

`slimbook/usr/share/slimbook/event-notify.py`