### PR TITLE
fix WM_CLASS: correct taskbar icon for GTK3 windows on KDE Plasma

### DIFF
--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -43,7 +43,6 @@ import fnmatch
 import datetime
 from dateutil import parser
 
-sys.argv[0] = "slimbook-indicator"
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -58,6 +57,7 @@ from gi.repository import Adw
 from gi.repository import Notify
 
 Adw.init()
+GLib.set_prgname("slimbook-indicator")
 
 Notify.init("Slimbook Client Notifications")
 notification = Notify.Notification.new("", "")
@@ -687,7 +687,6 @@ class PreferencesDialog(Adw.PreferencesDialog):
 
     def __init__(self):
         super().__init__()
-        self.set_wmclass("slimbook-indicator", "slimbook-indicator")
         self.set_title(_("Slimbook Preferences"))
 
         page = Adw.PreferencesPage()

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -33,6 +33,9 @@ import threading
 import subprocess
 import os
 import sys
+
+# force WM_CLASS for window manager icon matching
+sys.argv[0] = "slimbook-indicator"
 import shutil
 import common
 import webbrowser
@@ -686,9 +689,8 @@ class PreferencesDialog(Adw.PreferencesDialog):
 
     def __init__(self):
         super().__init__()
+        self.set_wmclass("slimbook-indicator", "slimbook-indicator")
         self.set_title(_("Slimbook Preferences"))
-        self._changes = False
-        self.connect("closed", self._on_dialog_closed)
 
         page = Adw.PreferencesPage()
         self.add(page)

--- a/slimbook/usr/share/slimbook/client.py
+++ b/slimbook/usr/share/slimbook/client.py
@@ -33,9 +33,6 @@ import threading
 import subprocess
 import os
 import sys
-
-# force WM_CLASS for window manager icon matching
-sys.argv[0] = "slimbook-indicator"
 import shutil
 import common
 import webbrowser
@@ -46,6 +43,7 @@ import fnmatch
 import datetime
 from dateutil import parser
 
+sys.argv[0] = "slimbook-indicator"
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")

--- a/slimbook/usr/share/slimbook/slimbook-client-autostart.desktop
+++ b/slimbook/usr/share/slimbook/slimbook-client-autostart.desktop
@@ -3,6 +3,7 @@ Type=Application
 Exec=/usr/bin/slimbookindicator
 Hidden=false
 NoDisplay=false
+StartupWMClass=slimbook-indicator
 Name[es_ES]=Slimbook Service
 Name=Slimbook Service
 X-GNOME-Autostart-Delay=3

--- a/slimbook/usr/share/slimbook/slimbook-indicator.desktop
+++ b/slimbook/usr/share/slimbook/slimbook-indicator.desktop
@@ -7,6 +7,7 @@ Terminal=false
 Hidden=false
 NoDisplay=false
 StartupNotify=false
+StartupWMClass=slimbook-indicator
 Encoding=UTF-8
 Name[ca_ES]=Servei Slimbook
 Name[es]=Servicio Slimbook


### PR DESCRIPTION
Fix incorrect icon in taskbar when Slimbook Service windows are open.

On KDE Plasma, GTK3 windows inherit the interpreter's WM_CLASS (python3), causing the taskbar to show a generic W icon instead of the Slimbook icon.

## Changes
- client.py: set sys.argv[0] = slimbook-indicator before GTK init so windows get the correct WM_CLASS
- slimbook-indicator.desktop: added StartupWMClass=slimbook-indicator
- slimbook-client-autostart.desktop: added StartupWMClass=slimbook-indicator

## Tested
KDE Plasma 6 (EXCALIBUR-16-AMD7)