### PR TITLE
touchpad: stop breaking the right corner partial lock

### DIFF
--- a/slimbook/usr/share/slimbook/touchpad.py
+++ b/slimbook/usr/share/slimbook/touchpad.py
@@ -22,6 +22,10 @@ import iohid
 
 import evdev
 import os
+import time
+import logging
+
+logger = logging.getLogger("slimbook.touchpad")
 
 BUTTON_SWITCH_USAGE_ID = (iohid.HID_USAGE_PAGE_DIGITIZER << 16) | iohid.HID_USAGE_DIGITIZER_BUTTON_SWITCH
 SURFACE_SWITCH_USAGE_ID = (iohid.HID_USAGE_PAGE_DIGITIZER << 16) | iohid.HID_USAGE_DIGITIZER_SURFACE_SWITCH
@@ -30,11 +34,22 @@ class Touchpad:
     MODE_UNKNOWN = 0
     MODE_HIDRAW = 1
     MODE_EVDEV = 2
-    
+
     STATE_UNKNOWN = 0
     STATE_LOCKED = 1
     STATE_UNLOCKED = 2
-    
+    # Partially locked: one of the two switches is off. The right corner button
+    # of some touchpads leaves the device in a state like this, and treating it
+    # as "unlocked" is what makes that button stop working (see get_state).
+    STATE_PARTIAL = 3
+
+    # Bits of the feature report, in the order they are declared in the report
+    # descriptor: surface switch first, button switch second. A bit set means
+    # the corresponding function is enabled.
+    SURFACE_BIT = 0x01
+    BUTTON_BIT = 0x02
+    ALL_BITS = SURFACE_BIT | BUTTON_BIT
+
     def __init__(self):
         self.mode = Touchpad.MODE_UNKNOWN
         self.report_id = 0
@@ -104,50 +119,159 @@ class Touchpad:
                 self.state = Touchpad.STATE_UNLOCKED
                 break
                 
+    def _find_i2c_device(self):
+        """Locate the i2c device backing this hidraw fd, and its driver.
+
+        Returns (device_name, driver_path) or (None, None). Everything is
+        derived from the file descriptor, so no device name is hardcoded: the
+        hidraw number, the i2c device name and the driver all vary per model.
+        """
+        if self.mode != Touchpad.MODE_HIDRAW or self.fd <= 0:
+            return None, None
+        try:
+            st = os.fstat(self.fd)
+            path = os.path.realpath("/sys/dev/char/{0}:{1}".format(
+                os.major(st.st_rdev), os.minor(st.st_rdev)))
+        except OSError:
+            return None, None
+
+        # Walk up until the i2c device that owns the HID device is found.
+        while path not in ("/", "/sys", ""):
+            driver_link = os.path.join(path, "driver")
+            subsystem_link = os.path.join(path, "subsystem")
+            if os.path.islink(driver_link) and os.path.islink(subsystem_link):
+                try:
+                    subsystem = os.path.basename(os.path.realpath(subsystem_link))
+                    driver = os.path.realpath(driver_link)
+                except OSError:
+                    return None, None
+                if subsystem == "i2c":
+                    return os.path.basename(path), driver
+            path = os.path.dirname(path)
+        return None, None
+
+    def _rebind_driver(self):
+        """Re-attach the i2c-hid driver, restoring the touchpad's own gestures.
+
+        Why this is needed: after the feature report is written, the firmware of
+        at least the ProX/Executive touchpad stops handling its own gestures --
+        the double tap and the right corner button go dead. Re-binding the
+        driver re-initialises the device and brings them back. This is what made
+        "Trackpad lock" break the right corner button.
+
+        Note the firmware also resets the feature to "unlocked" when it comes
+        back, so this must only be done when unlocking; doing it after locking
+        would undo the lock.
+
+        Requires root, which the service already has. Failure is not fatal: the
+        touchpad keeps working, only its gestures stay unresponsive.
+        """
+        device, driver = self._find_i2c_device()
+        if not device or not driver:
+            logger.debug("could not locate the i2c device, skipping rebind")
+            return False
+
+        try:
+            with open(os.path.join(driver, "unbind"), "w") as f:
+                f.write(device)
+            with open(os.path.join(driver, "bind"), "w") as f:
+                f.write(device)
+        except OSError as e:
+            logger.warning("could not rebind {0}: {1}".format(device, e))
+            return False
+
+        # The old fd points to a device that no longer exists.
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+        self.fd = 0
+        self.mode = Touchpad.MODE_UNKNOWN
+
+        # Wait for udev to recreate the node before re-opening. Re-opening too
+        # early would find no hidraw device and fall back to the evdev grab
+        # method, which loses the hardware lock and the LED -- exactly what this
+        # code path exists to preserve. Measured: the node is back in ~0.3 s.
+        for attempt in range(30):
+            time.sleep(0.05)
+            self.__init__()
+            if self.mode == Touchpad.MODE_HIDRAW:
+                logger.info("touchpad driver rebound, hardware gestures restored")
+                return True
+
+        logger.warning("touchpad did not come back as hidraw after rebinding")
+        return False
+
+    def _set_bits(self, value):
+        iohid.set_feature(self.fd, self.report_id, bytes([value & Touchpad.ALL_BITS]))
+
     def lock(self):
         if self.mode == Touchpad.MODE_HIDRAW and self.fd>0:
-            iohid.set_feature(self.fd,self.report_id,bytes([0x00]))
-        
+            self._set_bits(0x00)
+
         if self.mode == Touchpad.MODE_EVDEV and self.device:
             self.device.grab()
             self.state = Touchpad.STATE_LOCKED
-    
+
     def unlock(self):
         if self.mode == Touchpad.MODE_HIDRAW and self.fd>0:
-            iohid.set_feature(self.fd,self.report_id,bytes([0x03]))
-            
+            self._set_bits(Touchpad.ALL_BITS)
+            # Give the touchpad its own gestures back. Only on unlock: the
+            # firmware resets the feature to unlocked on re-init.
+            self._rebind_driver()
+
         if self.mode == Touchpad.MODE_EVDEV and self.device:
             self.device.ungrab()
             self.state = Touchpad.STATE_UNLOCKED
-    
+
     def toggle(self):
         self.get_state()
-    
+
         if (self.mode == Touchpad.MODE_HIDRAW and self.fd>0) or (self.mode == Touchpad.MODE_EVDEV and self.device):
-            if self.state == Touchpad.STATE_LOCKED:
-                
-                self.unlock()
-            elif self.state == Touchpad.STATE_UNLOCKED:
-                
+            if self.state == Touchpad.STATE_UNLOCKED:
                 self.lock()
-            elif self.state == Touchpad.STATE_UNKNOWN:
+            else:
+                # Locked, partially locked or unknown: unlock. Going to a known
+                # good state is always safer than locking further, and it means
+                # a partial lock can be cleared with the same action.
                 self.unlock()
-        
+
     def get_state(self):
-        
+
         if self.mode == Touchpad.MODE_HIDRAW and self.fd>0:
-            self.state = Touchpad.MODE_UNKNOWN
-            data = iohid.get_feature(self.fd, self.report_id,1)
+            self.state = Touchpad.STATE_UNKNOWN
             # mask is hardcoded, in the future maybe would be
             # better to obtain it from report descriptor
-            data = int(data[0]) & 0x03
-            
-            if (data == 0):
+            data = int(self.get_bits()) & Touchpad.ALL_BITS
+
+            if data == 0:
                 self.state = Touchpad.STATE_LOCKED
-            else:
+            elif data == Touchpad.ALL_BITS:
                 self.state = Touchpad.STATE_UNLOCKED
-        
+            else:
+                # Exactly one switch is off. Previously this branch was folded
+                # into STATE_UNLOCKED, which meant the state was overwritten
+                # with 0x00 or 0x03 on the next toggle and the partial lock was
+                # lost.
+                self.state = Touchpad.STATE_PARTIAL
+
         return self.state
-        
+
+    def get_bits(self):
+        """Raw value of the two switch bits, or 0 if not available."""
+        if self.mode != Touchpad.MODE_HIDRAW or self.fd <= 0:
+            return 0
+        # This ioctl intermittently fails with EINVAL on some devices. It is
+        # worth retrying: falling back to the evdev grab method loses the
+        # hardware lock, and with it the touchpad LED.
+        for attempt in range(4):
+            try:
+                return int(iohid.get_feature(self.fd, self.report_id, 1)[0])
+            except OSError as e:
+                if e.errno != 22 or attempt == 3:
+                    raise
+                time.sleep(0.01)
+        return 0
+
     def valid(self):
         return (self.mode != Touchpad.MODE_UNKNOWN)


### PR DESCRIPTION
## Fix the right corner partial lock being destroyed by Trackpad lock

Enabling **Trackpad lock** makes the right corner button of the ProX/Executive
touchpad stop working: it no longer lights its LED and no longer locks anything.
This PR fixes that, and two related problems found while investigating it.

All of this was measured on a **Slimbook Executive** (`Executive-RPL`, BIOS
`N.1.10GRU07`, EC `1.28`, touchpad `093A:0274` on I2C, kernel `7.1.4`, Plasma
6.7.3 on Wayland).

### What the feature report actually does

Writing the four possible values and checking the LED and the pointer by hand:

| Value | surface | buttons | LED | Behaviour |
|---|---|---|---|---|
| `0x00` | off | off | **on** | touchpad fully dead |
| `0x01` | on | off | off | pointer moves, clicks do not |
| `0x02` | off | on | off | pointer does not move |
| `0x03` | on | on | off | normal |

Two things worth noting:

- **The firmware retains all four values**, partial ones included.
- **Only `0x00` turns the LED on** — both bits have to be clear. A single-bit
  state cannot light it.

Also, the report descriptor declares `SurfaceSwitch` (`0x57`) *before*
`ButtonSwitch` (`0x58`), so **bit 0 is the surface and bit 1 the buttons** — the
reverse of what the order of the constants in the file suggests. Confirmed by
writing `0x01` and seeing the pointer still move while clicks stop.

### 1. `get_state()` collapsed partial states into unlocked

`get_state()` treated any non-zero value as `STATE_UNLOCKED`, so a partial lock
was reported as unlocked and the next `toggle()` overwrote it with `0x00` or
`0x03`. `STATE_PARTIAL` is now returned for those, and `toggle()` unlocks from
any state that is not fully unlocked — so a partial lock can be cleared with the
same gesture instead of being silently destroyed.

### 2. Writing the feature report costs the touchpad its own gestures

This is the part that actually explains the bug in the issue title, and it is not
what the code comments assume.

**The right corner gesture never writes the feature report.** With the partial
lock active and its LED on, the feature still reads `0x03`. So there is no bit
being overwritten — that explanation does not hold.

What does happen: **after the feature report is written, the firmware stops
handling its own gestures.** The double tap and the right corner button both go
dead. Re-binding the `i2c-hid` driver re-initialises the device and brings them
back, which is what `unlock()` now does.

Observed independently twice: once with `slimbook_service` and `Trackpad lock`
enabled, and once from a separate set of scripts writing the same report.

Two details that matter:

- **Only on unlock.** The firmware resets the feature to `0x03` when it comes
  back, so re-binding after locking would undo the lock ~0.3 s later.
- **Nothing is hardcoded.** The i2c device name (`i2c-UNIW0001:00` here) and its
  driver are derived from the file descriptor by walking up sysfs, since the
  hidraw number, the i2c device name and the driver all vary per model.

It needs root, which the service already has. Failure is logged and non-fatal:
the touchpad keeps working, only its gestures stay unresponsive.

Measured cost: ~0.3 s, and the code waits for the node to reappear rather than
sleeping a fixed amount.

### 3. The `EINVAL` fallback gives up the LED

The existing comment notes that `get_feature` intermittently fails with errno 22
and falls back to the evdev grab method. That fallback loses the hardware lock,
and with it the LED — the only visual confirmation the user gets. Measured here:
2400 consecutive reads without a single failure, so the failure is rare and
retrying is cheap. `get_bits()` now retries four times before giving up.

### Testing

Unit-level, calling the class directly:

- `lock()` → `0x00`, `STATE_LOCKED`, no re-bind, LED on.
- `unlock()` → `0x03`, driver re-bound, hardware gestures responding again.
- Writing `0x01` → `STATE_PARTIAL` (previously `STATE_UNLOCKED`).
- `toggle()` from partial → unlocks instead of locking further.

**End to end, with `slimbook-service` actually running the patched file** and
`OPT_TRACKPAD_LOCK` at its default of `True`. This Executive has **two
indicators**, one per top corner, and the full sequence now behaves like this:

1. **Right corner button** → right LED on, right half locked.
2. **Double tap on the left corner** → left LED on, right LED off, everything
   locked. The service wrote `0x00`.
3. **Double tap again** → unlocked, and **the right LED comes back on with the
   right half still locked**.

Step 3 is the interesting one: **the partial lock survives a full lock/unlock
cycle.** It is firmware state that outlives both the feature write and the
driver re-bind, so it does not need to be tracked or restored — it just needs
not to be misread, which is what the `get_state()` change fixes.

Worth stating plainly: the partial lock is **not observable from the OS at all**.
With the right half locked and its LED lit, `report 7` reads `0x03`. So a service
cannot know whether it is engaged; the best it can do is avoid clobbering the
state it can see and give the firmware its gestures back, which is what this PR
does.

I don't have other QC71 models to test on, so a second pair of eyes on the
re-bind path would be welcome — particularly whether the gestures going dead
after writing the feature happens on all of them or only on this touchpad
firmware.

### What I could not find out

- **Where the partial lock state lives.** Not in any feature report: all ten of
  the touchpad's feature reports were dumped and `report 7` is the only one
  carrying lock state (`report 6` is `DeviceMode`, `report 8` is `LatencyMode`,
  the rest are vendor blobs). Not in the input reports either — the constant bits
  of the button byte of `report 1` were checked with the partial lock engaged and
  they do not move. It appears to be entirely internal to the firmware.
- **Why the firmware goes deaf** after the feature report is written. Only that
  re-binding the driver fixes it.

If anyone at Slimbook has contact with the touchpad vendor (Uniform Industry,
`093A:0274`), the two changes that would make this unnecessary are: reflect the
partial lock state in the feature report — there are five constant bits spare in
the one already in use — and don't stop handling gestures when the host writes
it, or provide a way to hand control back without re-initialising the device.

### Other things found along the way, out of scope here

Not touched by this PR, since it changes one file only. Happy to send separate
PRs for any of them.

**`iohid.py`: `get_device_info` reads vendor and product as *signed* shorts.**

```python
info = struct.pack("Ihh", 0, 0, 0)          # line 142
data = struct.unpack("Ihh", status)         # line 144
```

`struct.hid_devinfo` has `__u16` fields, so this should be `IHH`. Any vendor or
product above `0x7FFF` comes back negative — a `0xC52B` reads as `-15061`. The
touchpad lookup happens to work because `0x93A` is 2362 and fits in a signed
short, but `str(DeviceInfo)` formats it with `{:04x}` and would render garbage
for such a device.

**`iohid.py`: `parse_report_descriptor` ignores the item size.** It computes
`bSize` on line 179 and uses it to advance, but every value is read as
`data[n+1]` — a single byte — regardless (lines 187, 201, 204, 210). Two- and
four-byte usages and usage pages are therefore truncated to their low byte. It
works for this touchpad because the usages it needs are one byte wide, but it
would misparse, for instance, a vendor-defined usage page (`0xFF00`), read as
`0x00`. Since the parser is only used to find the report id carrying the two
switches, this has no impact today.
